### PR TITLE
Shutdown must complete even if Allocator eats interrupt signal

### DIFF
--- a/src/main/java/stormpot/bpool/BSlot.java
+++ b/src/main/java/stormpot/bpool/BSlot.java
@@ -165,9 +165,4 @@ class BSlot<T extends Poolable> implements Slot, SlotInfo<T> {
   public void setStamp(long stamp) {
     this.stamp = stamp;
   }
-
-  @Override
-  public String toString() {
-    return "BSlot@" + Integer.toHexString(hashCode()) + "[ " + obj + " ]";
-  }
 }

--- a/src/main/java/stormpot/bpool/BlazePool.java
+++ b/src/main/java/stormpot/bpool/BlazePool.java
@@ -221,7 +221,7 @@ implements LifecycledResizablePool<T> {
 
   public Completion shutdown() {
     shutdown = true;
-    allocThread.interrupt();
+    allocThread.shutdown();
     return new BPoolShutdownCompletion(allocThread);
   }
 

--- a/src/main/java/stormpot/qpool/QueuePool.java
+++ b/src/main/java/stormpot/qpool/QueuePool.java
@@ -120,7 +120,7 @@ implements LifecycledResizablePool<T> {
 
   public Completion shutdown() {
     shutdown = true;
-    allocThread.interrupt();
+    allocThread.shutdown();
     return new QPoolShutdownCompletion(allocThread);
   }
 


### PR DESCRIPTION
If the interrupt happen inside the Allocator.allocate(Slot) method, and
then the allocator either clears the interruption status, or throws an
InterruptedException which in turn will be understood as poison, then the
allocation thread can miss the shutdown signal, and never begin the
shutdown sequence.
