### PR TITLE
TimeExpiration and TimeSpreadExpiration expose the generic type of Expiration.

### DIFF
--- a/src/main/java/stormpot/Config.java
+++ b/src/main/java/stormpot/Config.java
@@ -55,7 +55,7 @@ public class Config<T extends Poolable> implements Cloneable {
 
   private int size = 10;
   private Expiration<? super T> expiration =
-      new TimeSpreadExpiration(480000, 600000, TimeUnit.MILLISECONDS); // 8 to 10 minutes
+      new TimeSpreadExpiration<T>(480000, 600000, TimeUnit.MILLISECONDS); // 8 to 10 minutes
   private Allocator<?> allocator;
   private MetricsRecorder metricsRecorder;
   private ThreadFactory threadFactory = StormpotThreadFactory.INSTANCE;

--- a/src/main/java/stormpot/TimeExpiration.java
+++ b/src/main/java/stormpot/TimeExpiration.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
  * @author Chris Vest <mr.chrisvest@gmail.com>
  */
 // TODO 3.0 make class final
-public class TimeExpiration implements Expiration<Poolable> {
+public class TimeExpiration<T extends Poolable> implements Expiration<T> {
 
   private final long maxPermittedAgeMillis;
   private final TimeUnit unit;
@@ -59,7 +59,7 @@ public class TimeExpiration implements Expiration<Poolable> {
    * TimeExpiration.
    */
   @Override
-  public boolean hasExpired(SlotInfo<? extends Poolable> info) {
+  public boolean hasExpired(SlotInfo<? extends T> info) {
     return info.getAgeMillis() > maxPermittedAgeMillis;
   }
 

--- a/src/main/java/stormpot/TimeSpreadExpiration.java
+++ b/src/main/java/stormpot/TimeSpreadExpiration.java
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit;
  * @since 2.2
  */
 // TODO 3.0 make class final
-public class TimeSpreadExpiration implements Expiration<Poolable> {
+public class TimeSpreadExpiration<T extends Poolable> implements Expiration<T> {
 
   private final long lowerBoundMillis;
   private final long upperBoundMillis;
@@ -80,7 +80,7 @@ public class TimeSpreadExpiration implements Expiration<Poolable> {
    * declared expired.
    */
   @Override
-  public boolean hasExpired(SlotInfo<? extends Poolable> info) {
+  public boolean hasExpired(SlotInfo<? extends T> info) {
     long expirationAge = info.getStamp();
     if (expirationAge == 0) {
       long maxDelta = upperBoundMillis - lowerBoundMillis;

--- a/src/test/java/stormpot/PoolTest.java
+++ b/src/test/java/stormpot/PoolTest.java
@@ -90,9 +90,9 @@ public class PoolTest {
   @Rule public final TestRule failurePrinter = new FailurePrinterTestRule();
   
   private static final Expiration<Poolable> oneMsTTL =
-      new TimeExpiration(1, TimeUnit.MILLISECONDS);
+      new TimeExpiration<Poolable>(1, TimeUnit.MILLISECONDS);
   private static final Expiration<Poolable> fiveMsTTL =
-      new TimeExpiration(5, TimeUnit.MILLISECONDS);
+      new TimeExpiration<Poolable>(5, TimeUnit.MILLISECONDS);
   private static final Timeout longTimeout = new Timeout(1, TimeUnit.MINUTES);
   private static final Timeout mediumTimeout = new Timeout(10, TimeUnit.MILLISECONDS);
   private static final Timeout shortTimeout = new Timeout(1, TimeUnit.MILLISECONDS);

--- a/src/test/java/stormpot/TimeExpirationTest.java
+++ b/src/test/java/stormpot/TimeExpirationTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertTrue;
 public class TimeExpirationTest {
 
   private Expiration<Poolable> createExpiration(int ttl) {
-    return new TimeExpiration(ttl, TimeUnit.MILLISECONDS);
+    return new TimeExpiration<Poolable>(ttl, TimeUnit.MILLISECONDS);
   }
   
   private SlotInfo<?> infoWithAge(final long ageMillis) {
@@ -64,7 +64,7 @@ public class TimeExpirationTest {
   
   @Test(expected = IllegalArgumentException.class) public void
   timeUnitCannotBeNull() {
-    new TimeExpiration(10, null);
+    new TimeExpiration<Poolable>(10, null);
   }
   
   @Test public void
@@ -95,10 +95,10 @@ public class TimeExpirationTest {
 
   @Test public void
   mustHaveNiceToString() {
-    TimeExpiration a = new TimeExpiration(42, TimeUnit.DAYS);
+    TimeExpiration<Poolable> a = new TimeExpiration<Poolable>(42, TimeUnit.DAYS);
     assertThat(a.toString(), is("TimeExpiration(42 DAYS)"));
 
-    TimeExpiration b = new TimeExpiration(21, TimeUnit.MILLISECONDS);
+    TimeExpiration<Poolable> b = new TimeExpiration<Poolable>(21, TimeUnit.MILLISECONDS);
     assertThat(b.toString(), is("TimeExpiration(21 MILLISECONDS)"));
   }
 }

--- a/src/test/java/stormpot/simulations/ConstantTrafficBackgroundExpirationSim.java
+++ b/src/test/java/stormpot/simulations/ConstantTrafficBackgroundExpirationSim.java
@@ -30,8 +30,8 @@ public class ConstantTrafficBackgroundExpirationSim extends Sim {
   private static final Timeout timeout = new Timeout(1, TimeUnit.SECONDS);
 
   @Conf(Param.expiration)
-  public TimeSpreadExpiration expiration =
-      new TimeSpreadExpiration(200, 1000, TimeUnit.MILLISECONDS);
+  public TimeSpreadExpiration<Poolable> expiration =
+      new TimeSpreadExpiration<Poolable>(200, 1000, TimeUnit.MILLISECONDS);
 
   @Conf(Param.backgroundExpirationEnabled)
   public boolean[] backgroundExpiration = {true, false};

--- a/src/test/java/stormpot/simulations/TimeSpreadExpirationSim.java
+++ b/src/test/java/stormpot/simulations/TimeSpreadExpirationSim.java
@@ -25,10 +25,12 @@ import java.util.concurrent.TimeUnit;
  */
 @Sim.Simulation(pools = {BlazePool.class}, measurementTime = 60, output = Sim.Output.summary)
 public class TimeSpreadExpirationSim extends Sim {
+  @SuppressWarnings("rawtypes") // Not possible to have a generic array. It might be possible to make @Conf work with a
+                                // java.util.Set instead, but that's probably not worth the effort.
   @Conf(Param.expiration)
   public Expiration[] expirations = {
-      new TimeExpiration(2, TimeUnit.SECONDS),
-      new TimeSpreadExpiration(1, 2, TimeUnit.SECONDS)
+      new TimeExpiration<Poolable>(2, TimeUnit.SECONDS),
+      new TimeSpreadExpiration<Poolable>(1, 2, TimeUnit.SECONDS)
   };
 
   @Agents({@Agent, @Agent, @Agent, @Agent, @Agent, @Agent, @Agent})

--- a/src/test/java/stormpot/simulations/VariableTrafficSim.java
+++ b/src/test/java/stormpot/simulations/VariableTrafficSim.java
@@ -28,7 +28,7 @@ public class VariableTrafficSim extends Sim {
   private volatile long startTime;
 
   @Conf(Param.expiration)
-  public TimeExpiration expiration = new TimeExpiration(6, TimeUnit.SECONDS);
+  public TimeExpiration<Poolable> expiration = new TimeExpiration<Poolable>(6, TimeUnit.SECONDS);
 
   @Conf(Param.backgroundExpirationEnabled)
   public boolean[] backgroundExpiration = {true, false};


### PR DESCRIPTION
It seems that there are actually no dependency inside stormpot on this declaration. All tests seem to pass, at least locally.

This fixes #94.