### PR TITLE
Introduce basic checkstyle configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,21 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.15</version>
+        <configuration>
+          <configLocation>src/etc/checkstyle.xml</configLocation>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>

--- a/src/etc/checkstyle.xml
+++ b/src/etc/checkstyle.xml
@@ -1,0 +1,10 @@
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="Indentation">
+      <property name="basicOffset" value="2"/>
+      <property name="caseIndent" value="2"/>
+    </module>
+  </module>
+</module>

--- a/src/etc/checkstyle.xml
+++ b/src/etc/checkstyle.xml
@@ -2,9 +2,18 @@
         "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <module name="Checker">
   <module name="TreeWalker">
+    <module name="FileContentsHolder"/>
     <module name="Indentation">
       <property name="basicOffset" value="2"/>
       <property name="caseIndent" value="2"/>
     </module>
+    <module name="LineLength">
+      <property name="max" value="100"/>
+    </module>
+  </module>
+  <module name="SuppressionCommentFilter">
+    <property name="offCommentFormat" value="stop checking line length"/>
+    <property name="onCommentFormat" value="start checking line length"/>
+    <property name="checkFormat" value="LineLength"/>
   </module>
 </module>

--- a/src/main/java/stormpot/BSlot.java
+++ b/src/main/java/stormpot/BSlot.java
@@ -136,7 +136,7 @@ final class BSlot<T extends Poolable>
 }
 
 
-
+// stop checking line length
 /*
 The Java Object Layout rendition:
 
@@ -181,6 +181,7 @@ stormpot.BSlot object internals:
 Instance size: 184 bytes (estimated, add this JAR via -javaagent: to get accurate result)
 Space losses: 4 bytes internal + 4 bytes external = 8 bytes total
  */
+// start checking line length
 abstract class Padding1 {
   private int p0;
   private long p1, p2, p3, p4, p5, p6;

--- a/src/main/java/stormpot/CompoundExpiration.java
+++ b/src/main/java/stormpot/CompoundExpiration.java
@@ -18,9 +18,9 @@ package stormpot;
 /**
  * Provides a way to compose {@link Expiration}s.
  *
- * Given two {@link Expiration}s, this class considers that a slot is expired if any of the {@link Expiration} returns
- * {@code true}. This makes it easy to have an {@link Expiration} that expires both on time
- * ({@link stormpot.TimeExpiration}) and some other criteria.
+ * Given two {@link Expiration}s, this class considers that a slot is expired if any of the
+ * {@link Expiration} returns {@code true}. This makes it easy to have an {@link Expiration} that
+ * expires both on time ({@link stormpot.TimeExpiration}) and some other criteria.
  *
  * @author Guillaume Lederrey <guillaume.lederrey@gmail.com>
  * @since 2.4

--- a/src/main/java/stormpot/LifecycledResizablePool.java
+++ b/src/main/java/stormpot/LifecycledResizablePool.java
@@ -23,5 +23,5 @@ package stormpot;
  * @param <T> The type of {@link Poolable} contained in this pool.
  */
 public interface LifecycledResizablePool<T extends Poolable>
-extends LifecycledPool<T>, ResizablePool<T> {
+    extends LifecycledPool<T>, ResizablePool<T> {
 }

--- a/src/main/java/stormpot/QueueFactory.java
+++ b/src/main/java/stormpot/QueueFactory.java
@@ -25,13 +25,15 @@ final class QueueFactory {
   }
 
   static enum FactoryChoiceReason {
-    DEFAULT_FIRST_CHOICE("The " + QUEUE_IMPL_FIRST_CHOICE + " was available on the classpath, and the " +
-        QUEUE_IMPL + " system property did not specify any alternative implementation to use."),
-    SPECIFIED_CHOICE("The " + QUEUE_IMPL + " system property specified the queue implementation to use, " +
-        "specifically " + System.getProperty(QUEUE_IMPL) + "."),
-    DEFAULT_SECOND_CHOICE("The " + QUEUE_IMPL_FIRST_CHOICE + " was not available on the classpath, and the " +
-        QUEUE_IMPL + " system property did not specify any alternative implementation to use, so " +
-        QUEUE_IMPL_SECOND_CHOICE + " was used as the default fallback."),
+    DEFAULT_FIRST_CHOICE("The " + QUEUE_IMPL_FIRST_CHOICE + " was available on the classpath," +
+            " and the " + QUEUE_IMPL + " system property did not specify any alternative" +
+            " implementation to use."),
+    SPECIFIED_CHOICE("The " + QUEUE_IMPL + " system property specified the queue implementation" +
+            " to use, specifically " + System.getProperty(QUEUE_IMPL) + "."),
+    DEFAULT_SECOND_CHOICE("The " + QUEUE_IMPL_FIRST_CHOICE + " was not available on the" +
+            " classpath, and the " + QUEUE_IMPL + " system property did not specify any" +
+            " alternative implementation to use, so " + QUEUE_IMPL_SECOND_CHOICE + " was used" +
+            " as the default fallback."),
     DEFAULT_FALLBACK("")
     ;
 
@@ -49,9 +51,11 @@ final class QueueFactory {
   private static final Factory factory;
   private static final FactoryChoiceReason reason;
 
+  // stop checking line length
   private static final String QUEUE_IMPL = "stormpot.blocking.queue.impl";
   private static final String QUEUE_IMPL_FIRST_CHOICE = "java.util.concurrent.LinkedTransferQueue";
   private static final String QUEUE_IMPL_SECOND_CHOICE = LinkedBlockingQueue.class.getCanonicalName();
+  // start checking line length
 
   static {
     Factory theFactory = null;
@@ -85,9 +89,9 @@ final class QueueFactory {
     } catch (Exception e) {
       if (theReason == FactoryChoiceReason.SPECIFIED_CHOICE) {
         Exception exception = new Exception(
-            "WARNING: The queue implementation specified by the " + QUEUE_IMPL + " system property, " +
-            "specifically " + queueType + ", was determined to be unusable. " +
-            "Falling back to the " + QUEUE_IMPL_SECOND_CHOICE + " implementation.",
+            "WARNING: The queue implementation specified by the " + QUEUE_IMPL + " system" +
+            " property, specifically " + queueType + ", was determined to be unusable." +
+            " Falling back to the " + QUEUE_IMPL_SECOND_CHOICE + " implementation.",
             e);
         exception.printStackTrace();
       }


### PR DESCRIPTION
Style is now check during build at `verify` phase. Configuration is minimal and only checks for 2-space indentation at the moment. It can obviously be extended as required.

Build will fail if violations are found.

fixes #97