### PR TITLE
Newly allocated objects are claimed first

### DIFF
--- a/src/main/java/stormpot/AllocatorProcessFactory.java
+++ b/src/main/java/stormpot/AllocatorProcessFactory.java
@@ -24,6 +24,7 @@ interface AllocatorProcessFactory {
   <T extends Poolable> AllocatorProcess<T> buildAllocator(
       BlockingQueue<BSlot<T>> live,
       RefillPile<T> disregardPile,
+      RefillPile<T> newAllocations,
       PoolBuilder<T> builder,
       BSlot<T> poisonPill);
 }

--- a/src/main/java/stormpot/AllocatorProcessFactory.java
+++ b/src/main/java/stormpot/AllocatorProcessFactory.java
@@ -15,14 +15,14 @@
  */
 package stormpot;
 
-import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedTransferQueue;
 
 interface AllocatorProcessFactory {
   AllocatorProcessFactory THREADED = ThreadedAllocatorProcess::new;
   AllocatorProcessFactory DIRECT = DirectAllocatorProcess::new;
 
   <T extends Poolable> AllocatorProcess<T> buildAllocator(
-      BlockingQueue<BSlot<T>> live,
+      LinkedTransferQueue<BSlot<T>> live,
       RefillPile<T> disregardPile,
       RefillPile<T> newAllocations,
       PoolBuilder<T> builder,

--- a/src/main/java/stormpot/AllocatorProcessFactory.java
+++ b/src/main/java/stormpot/AllocatorProcessFactory.java
@@ -23,7 +23,7 @@ interface AllocatorProcessFactory {
 
   <T extends Poolable> AllocatorProcess<T> buildAllocator(
       BlockingQueue<BSlot<T>> live,
-      DisregardBPile<T> disregardPile,
+      RefillPile<T> disregardPile,
       PoolBuilder<T> builder,
       BSlot<T> poisonPill);
 }

--- a/src/main/java/stormpot/BAllocThread.java
+++ b/src/main/java/stormpot/BAllocThread.java
@@ -194,6 +194,9 @@ final class BAllocThread<T extends Poolable> implements Runnable {
 
   private void backgroundExpirationCheck() {
     disregardPile.refill();
+    if (!didAnythingLastIteration) {
+      newAllocations.refill();
+    }
     BSlot<T> slot = live.poll();
     if (slot == null) {
       newAllocations.refill();

--- a/src/main/java/stormpot/BlazePool.java
+++ b/src/main/java/stormpot/BlazePool.java
@@ -47,7 +47,7 @@ final class BlazePool<T extends Poolable>
   static final Exception EXPLICIT_EXPIRE_POISON =
       new Exception("Stormpot Poison: Expired");
 
-  private final BlockingQueue<BSlot<T>> live;
+  private final LinkedTransferQueue<BSlot<T>> live;
   private final RefillPile<T> disregardPile;
   private final RefillPile<T> newAllocations;
   private final AllocatorProcess<T> allocator;
@@ -131,7 +131,7 @@ final class BlazePool<T extends Poolable>
     long deadline = timeout.getDeadline();
     long timeoutLeft = timeout.getTimeoutInBaseUnit();
     TimeUnit baseUnit = timeout.getBaseUnit();
-    long maxWaitQuantum = baseUnit.convert(10, TimeUnit.MILLISECONDS);
+    long maxWaitQuantum = baseUnit.convert(100, TimeUnit.MILLISECONDS);
     for (;;) {
       slot = newAllocations.pop();
       if (slot == null) {

--- a/src/main/java/stormpot/BlazePool.java
+++ b/src/main/java/stormpot/BlazePool.java
@@ -16,7 +16,6 @@
 package stormpot;
 
 import java.util.Objects;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.TimeUnit;
 
@@ -56,7 +55,7 @@ final class BlazePool<T extends Poolable>
   private final MetricsRecorder metricsRecorder;
 
   /**
-   * Special slot used to signal that the pool has been shut down.
+   * A special slot used to signal that the pool has been shut down.
    */
   private final BSlot<T> poisonPill;
 

--- a/src/main/java/stormpot/DirectAllocatorProcess.java
+++ b/src/main/java/stormpot/DirectAllocatorProcess.java
@@ -31,6 +31,7 @@ class DirectAllocatorProcess<T extends Poolable> extends AllocatorProcess<T> {
   DirectAllocatorProcess(
       BlockingQueue<BSlot<T>> live,
       RefillPile<T> disregardPile,
+      RefillPile<T> newAllocations,
       PoolBuilder<T> builder,
       BSlot<T> poisonPill) {
     this.live = live;

--- a/src/main/java/stormpot/DirectAllocatorProcess.java
+++ b/src/main/java/stormpot/DirectAllocatorProcess.java
@@ -16,12 +16,12 @@
 package stormpot;
 
 import java.util.Objects;
-import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 class DirectAllocatorProcess<T extends Poolable> extends AllocatorProcess<T> {
-  private final BlockingQueue<BSlot<T>> live;
+  private final LinkedTransferQueue<BSlot<T>> live;
   private final RefillPile<T> disregardPile;
   private final BSlot<T> poisonPill;
   private final int size;
@@ -29,7 +29,7 @@ class DirectAllocatorProcess<T extends Poolable> extends AllocatorProcess<T> {
   private final AtomicInteger poisonedSlots;
 
   DirectAllocatorProcess(
-      BlockingQueue<BSlot<T>> live,
+      LinkedTransferQueue<BSlot<T>> live,
       RefillPile<T> disregardPile,
       RefillPile<T> newAllocations,
       PoolBuilder<T> builder,

--- a/src/main/java/stormpot/RefillPile.java
+++ b/src/main/java/stormpot/RefillPile.java
@@ -86,4 +86,10 @@ final class RefillPile<T extends Poolable>
     }
     return count > 0;
   }
+
+  @Override
+  public String toString() {
+    RefillSlot<T> currentValue = get();
+    return "RefillPile[" + (currentValue == STACK_END ? "EMPTY" : currentValue) + "]";
+  }
 }

--- a/src/main/java/stormpot/RefillSlot.java
+++ b/src/main/java/stormpot/RefillSlot.java
@@ -22,4 +22,9 @@ class RefillSlot<T extends Poolable> {
   RefillSlot(BSlot<T> slot) {
     this.slot = slot;
   }
+
+  @Override
+  public String toString() {
+    return "RefillSlot[slot=" + slot + ", next=" + next + "]";
+  }
 }

--- a/src/main/java/stormpot/RefillSlot.java
+++ b/src/main/java/stormpot/RefillSlot.java
@@ -15,11 +15,11 @@
  */
 package stormpot;
 
-class DisregardedBSlot<T extends Poolable> {
+class RefillSlot<T extends Poolable> {
   final BSlot<T> slot;
-  volatile DisregardedBSlot<T> next;
+  volatile RefillSlot<T> next;
 
-  DisregardedBSlot(BSlot<T> slot) {
+  RefillSlot(BSlot<T> slot) {
     this.slot = slot;
   }
 }

--- a/src/main/java/stormpot/ThreadedAllocatorProcess.java
+++ b/src/main/java/stormpot/ThreadedAllocatorProcess.java
@@ -15,14 +15,14 @@
  */
 package stormpot;
 
-import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.ThreadFactory;
 
 class ThreadedAllocatorProcess<T extends Poolable> extends AllocatorProcess<T> {
   private final BAllocThread<T> allocator;
   private final Thread allocatorThread;
   ThreadedAllocatorProcess(
-      BlockingQueue<BSlot<T>> live,
+      LinkedTransferQueue<BSlot<T>> live,
       RefillPile<T> disregardPile,
       RefillPile<T> newAllocations,
       PoolBuilder<T> builder,

--- a/src/main/java/stormpot/ThreadedAllocatorProcess.java
+++ b/src/main/java/stormpot/ThreadedAllocatorProcess.java
@@ -23,7 +23,7 @@ class ThreadedAllocatorProcess<T extends Poolable> extends AllocatorProcess<T> {
   private final Thread allocatorThread;
   ThreadedAllocatorProcess(
       BlockingQueue<BSlot<T>> live,
-      DisregardBPile<T> disregardPile,
+      RefillPile<T> disregardPile,
       PoolBuilder<T> builder,
       BSlot<T> poisonPill) {
     allocator = new BAllocThread<>(live, disregardPile, builder, poisonPill);

--- a/src/main/java/stormpot/ThreadedAllocatorProcess.java
+++ b/src/main/java/stormpot/ThreadedAllocatorProcess.java
@@ -24,9 +24,10 @@ class ThreadedAllocatorProcess<T extends Poolable> extends AllocatorProcess<T> {
   ThreadedAllocatorProcess(
       BlockingQueue<BSlot<T>> live,
       RefillPile<T> disregardPile,
+      RefillPile<T> newAllocations,
       PoolBuilder<T> builder,
       BSlot<T> poisonPill) {
-    allocator = new BAllocThread<>(live, disregardPile, builder, poisonPill);
+    allocator = new BAllocThread<>(live, disregardPile, newAllocations, builder, poisonPill);
     ThreadFactory factory = builder.getThreadFactory();
     allocatorThread = factory.newThread(allocator);
     allocatorThread.start();

--- a/src/test/java/blackbox/AbstractPoolTest.java
+++ b/src/test/java/blackbox/AbstractPoolTest.java
@@ -838,6 +838,11 @@ abstract class AbstractPoolTest<T extends Poolable> {
       obj.release();
     }
 
+    long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+    while (managedPool.getAllocationCount() < 3 && System.nanoTime() < deadline) {
+      Thread.yield();
+    }
+
     assertThat(managedPool.getAllocationCount()).isEqualTo(3);
   }
 

--- a/src/test/java/blackbox/PoolTest.java
+++ b/src/test/java/blackbox/PoolTest.java
@@ -1935,17 +1935,19 @@ class PoolTest extends AbstractPoolTest<GenericPoolable> {
     GenericPoolable obj = pool.claim(longTimeout);
     hasExpired.set(true);
 
-    latch.await();
-    hasExpired.set(false);
+    try {
+      latch.await();
+      hasExpired.set(false);
 
-
-    List<GenericPoolable> deallocations = allocator.getDeallocations();
-    // Synchronized to guard against concurrent modification from the allocator
-    //noinspection SynchronizationOnLocalVariableOrMethodParameter
-    synchronized (deallocations) {
-      assertThat(deallocations).doesNotContain(obj);
+      List<GenericPoolable> deallocations = allocator.getDeallocations();
+      // Synchronized to guard against concurrent modification from the allocator
+      //noinspection SynchronizationOnLocalVariableOrMethodParameter
+      synchronized (deallocations) {
+        assertThat(deallocations).doesNotContain(obj);
+      }
+    } finally {
+      obj.release();
     }
-    obj.release();
   }
 
   @ParameterizedTest

--- a/src/test/java/extensions/FailurePrinterExtension.java
+++ b/src/test/java/extensions/FailurePrinterExtension.java
@@ -55,8 +55,7 @@ public class FailurePrinterExtension implements Extension, BeforeEachCallback, A
     compilationMXBean = ManagementFactory.getCompilationMXBean();
     garbageCollectorMXBeans = ManagementFactory.getGarbageCollectorMXBeans();
     operatingSystemMXBean = ManagementFactory.getOperatingSystemMXBean();
-    if (threadMXBean.isCurrentThreadCpuTimeSupported())
-    {
+    if (threadMXBean.isCurrentThreadCpuTimeSupported()) {
       threadMXBean.setThreadCpuTimeEnabled(true);
     }
 

--- a/src/test/java/stormpot/RefillPileTest.java
+++ b/src/test/java/stormpot/RefillPileTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2011-2019 Chris Vest (mr.chrisvest@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package stormpot;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RefillPileTest {
+    private AtomicInteger poisonedSlots = new AtomicInteger();
+
+    @Test
+    void pushAndRefill() {
+        BlockingQueue<BSlot<GenericPoolable>> queue = new ArrayBlockingQueue<>(10);
+        RefillPile<GenericPoolable> pile = new RefillPile<>(queue);
+        BSlot<GenericPoolable> a = new BSlot<>(queue, poisonedSlots);
+        BSlot<GenericPoolable> b = new BSlot<>(queue, poisonedSlots);
+        pile.push(a);
+        pile.push(b);
+        assertTrue(pile.refill());
+        assertFalse(pile.refill());
+        assertThat(queue.poll()).isSameAs(b);
+        assertThat(queue.poll()).isSameAs(a);
+        assertThat(queue.poll()).isNull();
+        assertThat(pile.pop()).isNull();
+    }
+
+    @Test
+    void pushAndPop() {
+        BlockingQueue<BSlot<GenericPoolable>> queue = new ArrayBlockingQueue<>(10);
+        RefillPile<GenericPoolable> pile = new RefillPile<>(queue);
+        BSlot<GenericPoolable> a = new BSlot<>(queue, poisonedSlots);
+        BSlot<GenericPoolable> b = new BSlot<>(queue, poisonedSlots);
+        BSlot<GenericPoolable> c = new BSlot<>(queue, poisonedSlots);
+        pile.push(a);
+        pile.push(b);
+        assertThat(pile.pop()).isSameAs(b);
+        pile.push(c);
+        assertThat(pile.pop()).isSameAs(c);
+        assertThat(pile.pop()).isSameAs(a);
+        assertThat(pile.pop()).isNull();
+        assertFalse(pile.refill());
+    }
+}


### PR DESCRIPTION
A stack-like structure is introduced, which the claim slow-path consults before the live-queue.
Newly allocated objects are pushed onto this stack, allowing them to be claimed ahead of existing objects.
This allows integrating code to recover faster from temporary allocation failures, since they no longer have to go through the whole live-queue full of poisoned slots before they get to the successful allocations.
Instead, successful allocations now jump the queue. And with some luck, the background re-allocation of poisoned slots will resolve most of the pent up failed allocations.

This fixes #124