### PR TITLE
Use bytes for padding in BSlot

### DIFF
--- a/src/main/java/stormpot/BSlot.java
+++ b/src/main/java/stormpot/BSlot.java
@@ -158,9 +158,12 @@ final class BSlot<T extends Poolable>
   }
 }
 
+@SuppressWarnings("unused")
 abstract class Padding1 {
-  @SuppressWarnings("unused")
-  private int p0;
+  private byte p0;
+  private byte p1;
+  private byte p2;
+  private byte p3;
 }
 
 abstract class PaddedAtomicInteger extends Padding1 {


### PR DESCRIPTION
Using larger types are subject to reordering across class hierarchy boundaries
in future JVMs.

See https://shipilev.net/jvm/objects-inside-out/ and https://bugs.openjdk.java.net/browse/JDK-8237767