### PR TITLE
Update documentation with the inline pool mode

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -4,8 +4,32 @@
 
 Stormpot has many configuration options, but only one mandatory setting:
 You have to specify what `Allocator` or `Reallocator` implementation to use.
-This is enforced by the `Pool#from` method taking the `Allocator` (or `Reallocator`) as an argument.
+This is enforced by the `Pool#from`, `Pool#fromThreaded`, and `Pool#fromInline` methods, which all take the `Allocator` (or `Reallocator`) as an argument.
 The rest of the configuration options are optional, though there are a couple you most likely want to tweak.
+
+[[pool-modes]]
+=== Pool Modes
+
+The pool can operate in three different modes, which determine how objects are allocated:
+
+1. In the _default_ or _threaded_ mode, the objects in the pool are allocated by a background allocation thread.
+   The benefit of this is that the pool has a more predictable response time.
+   This also allows the pool to check object expiration in the background.
+   The pool can also automatically heal allocation failures, so fewer of these exceptions bubble out through the `claim` methods.
+   The drawback is that every pool in this mode will have a dedicated thread allocated for it.
+   If you plan on having many pool instances in your application, this might be costly.
+   This mode is obtained by creating a pool with the `Pool#from` or `Pool#fromThreaded` methods.
+2. The _inline_ mode omits the background thread, and instead allocates and deallocates objects as part of - or inline with - the `claim` method calls.
+   There is no background thread in this mode, and thus all features that depend on a background thread, like automatic allocation failure healing, are unavailable.
+   The benefit is that these pools take up fewer memory and CPU resources, due to the lack of the background thread.
+   This mode is obtained by creating a pool with the `Pool#fromInline`.
+3. In the _direct_ mode, the objects in the pool are pre-allocated before the pool is created.
+   This mode is even more restricted in its configuration than the inline mode.
+   There is no background thread, but there is also no need for one.
+   The objects in a direct pool never expire, and explicitly expiring them has no effect.
+   The objects are also never deallocated by the pool, because a direct pool has no allocator associated with it.
+   This also means that a direct pool cannot change its size; the `setTargetSize` method will throw an exception.
+   This mode is obtained by creating a pool with the `Pool#of(...)` method.
 
 === Pool Size
 
@@ -73,7 +97,7 @@ In fact, it is so performance sensitive, that reading the time from the system c
 
 === Background Expiration Checking
 
-Every Stormpot pool starts a background thread to take care of all the allocation and deallocation that needs to happen.
+Stormpot pools in the default or threaded modes will start a background thread to take care of all the allocation and deallocation that needs to happen.
 This background thread can also perform expiration checks on the objects in the pool, when it has nothing better to do.
 
 Background expiration checks are on by default, because they are very useful for applications that may experience periods of low activity.
@@ -116,7 +140,7 @@ Once you have your `MetricsRecorder` implementation, you just set an instance of
 
 === ThreadFactory
 
-Stormpot creates a background thread per pool instance.
+Stormpot pools in the default or threaded mode create a background thread per pool instance.
 This thread is in charge of allocating and deallocating objects for the pool.
 This means that the threads that access the pool to claim objects, don't have to pay the overhead of allocating any of the objects themselves.
 The latency for claiming objects is thereby reduced, and made more predictable.
@@ -130,9 +154,11 @@ Whatever the case, if the background thread needs to be created in a particular 
 
 The default `ThreadFactory` is based on the `Executors#defaultThreadFactory`, but also assigns the thread a name, that makes it recognisable as a Stormpot background thread.
 
+The thread factory setting is not used by pools that operate in the _inline_ mode.
+
 === Precise Leak Detection
 
-Stormpot has precise leak detection enabled by default, because the CPU overhead is very low.
+Stormpot has precise leak detection enabled by default (except in the direct pool mode) because the CPU overhead is very low.
 There is, however, a bit of memory overhead.
 Therefor, it may make sense to disable this in use cases where memory is very constrained, and/or the pool contains a very large number of objects.
 If you pool upwards a hundred thousand objects or more, you might want to disable it for performance reasons.

--- a/docs/trouble-shooting.adoc
+++ b/docs/trouble-shooting.adoc
@@ -23,11 +23,15 @@ How do I find out if I have leaked an object?::
   The precise leak detector will notice the last case, but cannot tell you where in the code the problem is.
 
 Why are there so many "Stormpot" threads in my program?::
-  Stormpot starts a thread for every pool instance you create.
+  Stormpot by default starts a thread for every pool instance you create.
   It does not share threads across pool instances.
+  You can use the "inline" pool mode if this is a problem.
+  See the `Pool#fromInline` method for more information about the inline pool mode.
 
 I'm not allowed to start threads in my environment, or I get an exception about not being able to start a thread when I try to create an pool instance!::
   Some environments restrict the ability to create threads.
   These environments often have a way to get around that restriction, for instance by creating threads with a particular `ThreadGroup` or creating the thread in a particular privileged part of the code.
   Stormpot can be configured to use a specific `ThreadFactory` for creating its threads.
   So giving it a `ThreadFactory` that knows how to create threads in your particular environment, is the way to get around these restrictions.
+  Alternatively you can use the "inline" pool mode, where the pool operates without a background thread.
+  See the `Pool#fromInline` method for more information about the inline pool mode.

--- a/docs/tutorial.adoc
+++ b/docs/tutorial.adoc
@@ -74,7 +74,8 @@ If you call `claim` on a depleted pool, the call will block until at least one o
 More than one thread at a time can be blocked trying to claim objects from the pool.
 The claim call does not guarantee fairness, so there is no way to know before hand, which of the threads will be unblocked when an object is released.
 
-The pool has a background thread dedicated to allocating and deallocating the poolable objects, because these are presumably expensive operations.
+The pool has an allocation process to allocating and deallocating the poolable objects, because these are presumably expensive operations.
+The allocation process is by default implemented as a dedicated background thread.
 This way, the threads that come to the pool to claim objects, don't have to pay the cost of allocating those objects.
 This reduces the latency for claim in the general case.
 
@@ -82,21 +83,21 @@ In essence, the central parts of the pool fit together like this:
 
 [ditaa]
 ----
-+-------------+                 claim>              +------------------------+
-:             +------------------------------------>|                        |
-|  User code  |                                     |          Pool          |
-|             |           +-------------+   <claim  |                        |
-|             |   ‹use›   |             +<----------+  +------------------+  |
-|             +=--------->+   Poolable  |           |  | Allocator Thread |  |
-|             |           |             |           |  +--+---------------+  |
-|             |  release  |   +------+  |           |     |                  |
-|             +---------->+-->+ Slot +--+---------->+     | allocate/        |
-|             |           |   +------+  |           |     | deallocate       |
-+-------------+           |             |           |     v                  |
-                          +- - - - - - -+           |  +------------------+  |
-                                                    |  |    Allocator     |  |
-                                                    |  +------------------+  |
-                                                    +------------------------+
++-------------+                 claim>              +--------------------------+
+:             +------------------------------------>|                          |
+|  User code  |                                     |           Pool           |
+|             |           +-------------+   <claim  |                          |
+|             |   ‹use›   |             +<----------+  +--------------------+  |
+|             +=--------->+   Poolable  |           |  | Allocation Process |  |
+|             |           |             |           |  +--+-----------------+  |
+|             |  release  |   +------+  |           |     |                    |
+|             +---------->+-->+ Slot +------------->+     | allocate/          |
+|             |           |   +------+  |           |     | deallocate         |
++-------------+           |             |           |     v                    |
+                          +-------------+           |  +--------------------+  |
+                                                    |  |     Allocator      |  |
+                                                    |  +--------------------+  |
+                                                    +--------------------------+
 ----
 
 === Object Pooling in Practice
@@ -120,11 +121,15 @@ However, it is a skeleton to which we can add the functionality and the expensiv
 
 Next, the pool can't create instances of this class by itself.
 It needs the help of an `Allocator` implementation to do that.
-The allocation of these objects will be happening in a dedicated allocation thread, such that this thread pays the cost of the presumably expensive allocation.
+The allocation of these objects will by default be happening in a dedicated allocation thread, such that this thread pays the cost of the presumably expensive allocation.
 Therefor, it is generally a good idea to do as much work as possible during the allocation, such that it is as cheap as possible to claim and use the objects.
 There is one moderation to this rule, however, because the pool only has one allocation thread.
 The more expensive objects are to create, the longer it will take to fill the pool.
 Likewise, if the objects expire and churn with a high rate, the allocation thread might not be able to keep up with the demand for reallocations.
+
+The above describes the default _threaded_ allocation mode.
+The pool can also be created in other modes where the objects are either all allocated up front, or inline with the claim calls.
+See the configuration page for descriptions of the different link:config.html#pool-modes[allocation modes].
 
 Here is what an `Allocator` that allocates the above objects, can look like:
 
@@ -254,9 +259,29 @@ All the other configuration properties have somewhat reasonable default values.
 Other properties that might be interesting to configure, include the pool size, and the `Expiration` instance.
 See the link:config.html[configuration reference] page for more information on how to configure Stormpot.
 
-=== Directly Pooling Objects
+=== Alternative Pool Modes
 
-Stormpot comes with an alternative operating mode, where the objects to be pooled are directly given to the pool upon construction, rather than being allocated and maintained in the background.
+Stormpot comes with two alternative pool modes: the inline pool mode and the direct pool mode.
+
+==== The Inline Pool Mode
+
+In the inline pool mode the objects are initially allocated when the pool is created, and then deallocated and reallocated as part of the `claim` calls.
+
+This mode is enabled by creating the pool with the `Pool.fromInline()` method:
+
+[source,java]
+----
+include::../src/test/java/examples/Examples.java[tag=inlinePoolExample]
+----
+
+The inline mode is similar to the threaded mode in many aspects, but with the services provided by the background thread disabled.
+For instance, there is no background expiration checking, and no background reallocation of failed allocations.
+
+Since the pool in the inline mode will deallocate and allocate objects as part of the `claim` calls, it is possible that it will take longer for the call to return than what is specified by the given timeout.
+
+==== The Direct Pool Mode
+
+In the direct pool mode the objects to be pooled are directly given to the pool upon construction, rather than being allocated and maintained in the background.
 
 This mode is enabled by creating the pool with the `Pool.of(...)` method:
 
@@ -275,3 +300,4 @@ This makes mode good for temporary and short-lived pools, or for when the object
 
 One drawback of this mode, is that the pool cannot be resized.
 The size of these pools are fixed, and given by the number of objects passed to the `Pool.of(...)` method.
+If you need to be able to resize the pool, then you should take a look at the _inline_ pool mode instead.

--- a/src/main/java/stormpot/Pool.java
+++ b/src/main/java/stormpot/Pool.java
@@ -80,7 +80,7 @@ public abstract class Pool<T extends Poolable> extends PoolTap<T> {
    * {@linkplain PoolBuilder#build build} a {@link Pool} instance with the
    * desired configuration.
    *
-   * This method is synonymous for {@link #fromAsync(Allocator)}.
+   * This method is synonymous for {@link #fromThreaded(Allocator)}.
    *
    * @param allocator The allocator we want our pools to use. This cannot be
    * `null`.
@@ -88,10 +88,10 @@ public abstract class Pool<T extends Poolable> extends PoolTap<T> {
    * and the type of objects that the configured pools will contain.
    * @return A {@link PoolBuilder} that admits additional configurations,
    * before the pool instance is {@linkplain PoolBuilder#build() built}.
-   * @see #fromAsync(Allocator)
+   * @see #fromThreaded(Allocator)
    */
   public static <T extends Poolable> PoolBuilder<T> from(Allocator<T> allocator) {
-    return fromAsync(allocator);
+    return fromThreaded(allocator);
   }
 
   /**
@@ -102,9 +102,9 @@ public abstract class Pool<T extends Poolable> extends PoolTap<T> {
    *
    * The returned {@link PoolBuilder} will build pools that allocate and deallocate
    * objects in a background thread.
-   * Hence the "async" in the name; the objects are created and destroyed
-   * asynchronously, out of band with the threads that call into the pool to claim
-   * objects.
+   * Hence the "threaded" in the name; the objects are created and destroyed
+   * by the background thread, out of band with the threads that call into the pool to
+   * claim objects.
    *
    * By moving the allocation of objects to a background thread, it can be guaranteed
    * that the timeouts given to {@link #claim(Timeout) claim} will always be honoured.
@@ -118,7 +118,7 @@ public abstract class Pool<T extends Poolable> extends PoolTap<T> {
    * @return A {@link PoolBuilder} that admits additional configurations,
    * before the pool instance is {@linkplain PoolBuilder#build() built}.
    */
-  public static <T extends Poolable> PoolBuilder<T> fromAsync(Allocator<T> allocator) {
+  public static <T extends Poolable> PoolBuilder<T> fromThreaded(Allocator<T> allocator) {
     return new PoolBuilder<>(threaded(), allocator);
   }
 

--- a/src/main/java/stormpot/PoolBuilder.java
+++ b/src/main/java/stormpot/PoolBuilder.java
@@ -33,7 +33,7 @@ import static stormpot.StormpotThreadFactory.INSTANCE;
  * {@link #build()} method.
  *
  * Pool builder instances are obtained by calling one of the `from*`
- * methods on {@link Pool}, such as {@link Pool#fromAsync(Allocator)}.
+ * methods on {@link Pool}, such as {@link Pool#fromThreaded(Allocator)}.
  *
  * This class is made thread-safe by having the fields be protected by the
  * intrinsic object lock on the `PoolBuilder` object itself. This way, pools

--- a/src/test/java/blackbox/ThreadedPoolTest.java
+++ b/src/test/java/blackbox/ThreadedPoolTest.java
@@ -20,9 +20,9 @@ import stormpot.GenericPoolable;
 import stormpot.Pool;
 import stormpot.PoolBuilder;
 
-public class AsyncPoolTest extends ThreadBasedPoolTest {
+public class ThreadedPoolTest extends ThreadBasedPoolTest {
   @Override
   protected PoolBuilder<GenericPoolable> createInitialPoolBuilder(AlloKit.CountingAllocator allocator) {
-    return Pool.fromAsync(allocator);
+    return Pool.fromThreaded(allocator);
   }
 }

--- a/src/test/java/blackbox/slow/ThreadedPoolIT.java
+++ b/src/test/java/blackbox/slow/ThreadedPoolIT.java
@@ -20,9 +20,9 @@ import stormpot.GenericPoolable;
 import stormpot.Pool;
 import stormpot.PoolBuilder;
 
-class AsyncPoolIT extends ThreadBasedPoolIT {
+class ThreadedPoolIT extends ThreadBasedPoolIT {
   @Override
   protected PoolBuilder<GenericPoolable> createPoolBuilder(AlloKit.CountingAllocator allocator) {
-    return Pool.fromAsync(allocator);
+    return Pool.fromThreaded(allocator);
   }
 }

--- a/src/test/java/examples/Examples.java
+++ b/src/test/java/examples/Examples.java
@@ -104,6 +104,19 @@ class Examples {
     // end::directPoolExample[]
   }
 
+  @Test
+  void inlinePoolExample() throws Exception {
+    MyAllocator allocator = new MyAllocator();
+    // tag::inlinePoolExample[]
+    Pool<MyPoolable> pool = Pool.fromInline(allocator).build();
+    MyPoolable obj = pool.claim(TIMEOUT);
+    if (obj != null) {
+      System.out.println(obj);
+      obj.release();
+    }
+    // end::inlinePoolExample[]
+  }
+
   @SuppressWarnings("InnerClassMayBeStatic")
   // tag::poolableGenericExample[]
   public class GenericPoolable implements Poolable {


### PR DESCRIPTION
Also rename `Pool#fromAsync` to `Pool#fromThreaded`.
If there is ever a time where we want to implement a pool that is asynchronous in the sense of making use of CompletableFutures, then it will be good to have the "async" name available then.