### PR TITLE
fixup Asciidoclet using include paths

### DIFF
--- a/src/main/java/stormpot/ManagedPool.java
+++ b/src/main/java/stormpot/ManagedPool.java
@@ -27,9 +27,9 @@ import javax.management.MXBean;
  * Once you have created your pool, it is easy to expose it through the platform
  * MBeanServer, or any MBeanServer you like:
  *
- * [source,java]
+ * [source,java,indent=0]
  * ----
- * include::../src/test/java/examples/Examples.java[tag=managedPoolExample]
+ * include::src/test/java/examples/Examples.java[tag=managedPoolExample]
  * ----
  *
  * Using the platform MBeanServer will make the pool visible to tools like

--- a/src/main/java/stormpot/MetricsRecorder.java
+++ b/src/main/java/stormpot/MetricsRecorder.java
@@ -30,7 +30,7 @@ package stormpot;
  *
  * [source,java]
  * ----
- * include::../src/test/java/examples/DropwizardMetricsRecorder.java[lines=16..-1]
+ * include::src/test/java/examples/DropwizardMetricsRecorder.java[lines=16..-1]
  * ----
  *
  * @since 2.3

--- a/src/main/java/stormpot/Pool.java
+++ b/src/main/java/stormpot/Pool.java
@@ -33,9 +33,9 @@ import static stormpot.AllocationProcess.*;
  * {@link Poolable#release() releasing} that object again. By far the most
  * common idiom to achieve this is with a `try-finally` clause:
  *
- * [source,java]
+ * [source,java,indent=0]
  * ----
- * include::../src/test/java/examples/Examples.java[tag=poolClaimExample]
+ * include::src/test/java/examples/Examples.java[tag=poolClaimExample]
  * ----
  *
  * The pools are resizable, and can have their capacity changed at any time

--- a/src/main/java/stormpot/PoolTap.java
+++ b/src/main/java/stormpot/PoolTap.java
@@ -68,9 +68,9 @@ public abstract class PoolTap<T extends Poolable> {
    * Here's an example code snippet, where an object is claimed, printed to
    * `System.out`, and then released back to the pool:
    *
-   * [source,java]
+   * [source,java,indent=0]
    * ----
-   * include::../src/test/java/examples/Examples.java[tag=poolClaimPrintExample]
+   * include::src/test/java/examples/Examples.java[tag=poolClaimPrintExample]
    * ----
    *
    * Memory effects:

--- a/src/main/java/stormpot/Poolable.java
+++ b/src/main/java/stormpot/Poolable.java
@@ -31,16 +31,16 @@ package stormpot;
  *
  * A simple correct implementation of the Poolable interface looks like this:
  *
- * [source,java]
+ * [source,java,indent=0]
  * ----
- * include::../src/test/java/examples/Examples.java[tag=poolableGenericExample]
+ * include::src/test/java/examples/Examples.java[tag=poolableGenericExample]
  * ----
  *
  * This can be shortened further by extending the {@link BasePoolable} class:
  *
- * [source,java]
+ * [source,java,indent=0]
  * ----
- * include::../src/test/java/examples/Examples.java[tag=poolableBaseExample]
+ * include::src/test/java/examples/Examples.java[tag=poolableBaseExample]
  * ----
  *
  * It is also possible to directly use the {@link Pooled} implementation, which

--- a/src/main/java/stormpot/Reallocator.java
+++ b/src/main/java/stormpot/Reallocator.java
@@ -43,7 +43,7 @@ public interface Reallocator<T extends Poolable> extends Allocator<T> {
    *
    * This method is effectively equivalent to the following:
    *
-   * [source,java]
+   * [source,java,indent=0]
    * --
    * include::src/test/java/examples/Examples.java[tag=reallocatorExample]
    * --


### PR DESCRIPTION
Hi @chrisvest, I was looking for some real-world Asciidoclet examples and came across your project.

While implementing Asciidoclet support for IntelliJ (https://github.com/asciidoctor/asciidoctor-intellij-plugin/issues/103) I found some include paths that should start at the root of the project (at least that's how I read the Asciidoclet documentation). Strangely enough this didn't affect the Javadoc generation. 

Now the include paths are consistent. I generated the docs locally and they worked before and after.

This PR also fixed the indentation of included source snippets. 

I wasn't sure if the PR should go into 3.1 or 3.2. If I should provide a PR for 3.1 as well please let me know. 

If you happen to be a user of IntelliJ and the AsciiDoc plugin for IntelliJ I'm happy for feedback regarding Asciidoclet support via GitHub issues.
