### PR TITLE
Add a tryClaim which doesn't take a Timeout

### DIFF
--- a/src/main/java/stormpot/BlazePoolThreadLocalTap.java
+++ b/src/main/java/stormpot/BlazePoolThreadLocalTap.java
@@ -36,6 +36,11 @@ final class BlazePoolThreadLocalTap<T extends Poolable> extends PoolTap<T> {
 
   @Override
   public T claim(Timeout timeout) throws PoolException, InterruptedException {
-    return pool.tlrClaim(timeout, cache);
+    return pool.claim(timeout, cache);
+  }
+
+  @Override
+  public T tryClaim() {
+    return pool.tryClaim(cache);
   }
 }

--- a/src/main/java/stormpot/Pool.java
+++ b/src/main/java/stormpot/Pool.java
@@ -281,6 +281,11 @@ public abstract class Pool<T extends Poolable> extends PoolTap<T> {
       public T claim(Timeout timeout) throws PoolException, InterruptedException {
         return Pool.this.claim(timeout);
       }
+
+      @Override
+      public T tryClaim() {
+        return Pool.this.tryClaim();
+      }
     };
   }
 

--- a/src/test/java/stormpot/WhiteboxPoolTest.java
+++ b/src/test/java/stormpot/WhiteboxPoolTest.java
@@ -58,6 +58,11 @@ class WhiteboxPoolTest {
         delegatedToPool.set(true);
         return null;
       }
+
+      @Override
+      public Poolable tryClaim() {
+        return null;
+      }
     };
     pool.getThreadSafeTap().claim(longTimeout);
     assertTrue(delegatedToPool.get());


### PR DESCRIPTION
Add a tryClaim which doesn't take a Timeout, and only claims an object if one is immediately available.

Refactored the impl of private methods used by claim to simplify the code logic.