### PR TITLE
Fix flaky DefaultPoolTest

### DIFF
--- a/src/test/java/blackbox/DefaultPoolTest.java
+++ b/src/test/java/blackbox/DefaultPoolTest.java
@@ -25,4 +25,10 @@ class DefaultPoolTest extends ThreadBasedPoolTest {
   protected PoolBuilder<GenericPoolable> createInitialPoolBuilder(AlloKit.CountingAllocator allocator) {
     return Pool.from(allocator);
   }
+
+  @Override
+  void claimWhenInterruptedMustNotThrowIfObjectIsAvailableViaCache(Taps taps) throws Exception {
+    noBackgroundExpirationChecking(); // Prevent background expiration checking from claiming cached object.
+    super.claimWhenInterruptedMustNotThrowIfObjectIsAvailableViaCache(taps);
+  }
 }


### PR DESCRIPTION
The `claimWhenInterruptedMustNotThrowIfObjectIsAvailableViaCache` relies on the thread-local cache having a previously claimed object ready to be reclaimed. However, background expiration checking would sometimes race and claim the object temporarily, preventing a TLR_CLAIM by the test. This would cause the test to go down the slow claim path, which is susceptible to interrupts, and which the test was asserting would not happen.