### PR TITLE
Fix pool shrinking with new allocations

### DIFF
--- a/src/main/java/stormpot/BAllocThread.java
+++ b/src/main/java/stormpot/BAllocThread.java
@@ -154,6 +154,10 @@ final class BAllocThread<T extends Poolable> implements Runnable {
   }
 
   private void reduceSizeByDeallocating(BSlot<T> slot) {
+    if (slot == null || !didAnythingLastIteration) {
+      disregardPile.refill();
+      newAllocations.refill();
+    }
     slot = slot == null ? live.poll() : slot;
     if (slot != null) {
       if (slot.isDead() || slot.live2dead()) {


### PR DESCRIPTION
Make BAllocThread.reduceSizeByDeallocating() call refill on the disregardPile and the newAllocations. Otherwise, the pool might not be able to deallocate objects allocated but unused prior to a new target size being set. This is normally not a big deal for pools that have any sort of activity, but the `ThreadedPoolTest.decreasingSizeMustNotDeallocateTlrClaimedObjects` test could end up in an infinite loop, and break the build.