### PR TITLE
Fix flaky ThreadedPoolTest.mustNotHoldOnToDeallocatedObjectsWhenLeakDetectionIsEnabled

### DIFF
--- a/src/test/java/blackbox/AllocatorBasedPoolTest.java
+++ b/src/test/java/blackbox/AllocatorBasedPoolTest.java
@@ -1660,7 +1660,6 @@ abstract class AllocatorBasedPoolTest extends AbstractPoolTest<GenericPoolable> 
     // It's enabled by default
     AtomicBoolean hasExpired = new AtomicBoolean();
     builder.setExpiration(expire($expiredIf(hasExpired)));
-    builder.setBackgroundExpirationEnabled(false);
     createPool();
 
     // Allocate an object

--- a/src/test/java/blackbox/AllocatorBasedPoolTest.java
+++ b/src/test/java/blackbox/AllocatorBasedPoolTest.java
@@ -1660,6 +1660,7 @@ abstract class AllocatorBasedPoolTest extends AbstractPoolTest<GenericPoolable> 
     // It's enabled by default
     AtomicBoolean hasExpired = new AtomicBoolean();
     builder.setExpiration(expire($expiredIf(hasExpired)));
+    builder.setBackgroundExpirationEnabled(false);
     createPool();
 
     // Allocate an object
@@ -1681,13 +1682,14 @@ abstract class AllocatorBasedPoolTest extends AbstractPoolTest<GenericPoolable> 
     // Clear the allocator lists to remove the last references
     allocator.clearLists();
 
-    // GC to force the object through finalization life cycle
-    System.gc();
-    System.gc();
-    System.gc();
+    int iterationCount = 0;
+    do {
+      // GC to force the object through finalization life cycle
+      System.gc();
+      assertThat(iterationCount++).isLessThan(1000);
 
-    // Now our weakReference must have been cleared
-    assertNull(weakReference.get());
+      // Now our weakReference must eventually have been cleared
+    } while (weakReference.get() != null);
   }
 
   @Test

--- a/src/test/java/blackbox/DefaultPoolTest.java
+++ b/src/test/java/blackbox/DefaultPoolTest.java
@@ -25,10 +25,4 @@ class DefaultPoolTest extends ThreadBasedPoolTest {
   protected PoolBuilder<GenericPoolable> createInitialPoolBuilder(AlloKit.CountingAllocator allocator) {
     return Pool.from(allocator);
   }
-
-  @Override
-  void claimWhenInterruptedMustNotThrowIfObjectIsAvailableViaCache(Taps taps) throws Exception {
-    noBackgroundExpirationChecking(); // Prevent background expiration checking from claiming cached object.
-    super.claimWhenInterruptedMustNotThrowIfObjectIsAvailableViaCache(taps);
-  }
 }

--- a/src/test/java/blackbox/ThreadBasedPoolTest.java
+++ b/src/test/java/blackbox/ThreadBasedPoolTest.java
@@ -702,4 +702,22 @@ abstract class ThreadBasedPoolTest extends AllocatorBasedPoolTest {
       d.release();
     }
   }
+
+  @Override
+  void claimWhenInterruptedMustNotThrowIfObjectIsAvailableViaCache(Taps taps) throws Exception {
+    noBackgroundExpirationChecking(); // Prevent background expiration checking from claiming cached object.
+    super.claimWhenInterruptedMustNotThrowIfObjectIsAvailableViaCache(taps);
+  }
+
+  @Override
+  void mustNotHoldOnToDeallocatedObjectsWhenLeakDetectionIsEnabled() throws Exception {
+    noBackgroundExpirationChecking();
+    super.mustNotHoldOnToDeallocatedObjectsWhenLeakDetectionIsEnabled();
+  }
+
+  @Override
+  void tryClaimMustReturnIfPoolIsNotEmpty(Taps taps) throws Exception {
+    noBackgroundExpirationChecking();
+    super.tryClaimMustReturnIfPoolIsNotEmpty(taps);
+  }
 }


### PR DESCRIPTION
When background expiration checking was enabled, it was possible for the test to race with the background expiration check. This could cause slots to end up in the disregardPile or live queue, instead of the thread-local slot as intended. The disregardPile or live queue would then maintain a strong reference to the object that we were hoping would be deallocated and all references purged, besides the weak reference in the test. The fix is to disable background expiration checking in this test.