### PR TITLE
Make PoolIT test less flaky

### DIFF
--- a/src/test/java/blackbox/slow/PoolIT.java
+++ b/src/test/java/blackbox/slow/PoolIT.java
@@ -290,7 +290,14 @@ abstract class PoolIT {
     assertThrows(PoolException.class, () -> pool.claim(longTimeout).release());
     long prev = 0, curr;
     for (int i = 0; i < 50; i++) {
+      long start = System.nanoTime();
       Thread.sleep(100);
+      long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+      if (elapsedMillis >= 150) {
+        // Ignore outliers with very high sleep time.
+        i--;
+        continue;
+      }
       curr = counter.get();
       long delta = curr - prev;
       prev = curr;


### PR DESCRIPTION
High sleep time in the test thread could cause the background allocation thread to run ahead and increase the allocation counter too much.