### PR TITLE
Fix test flakiness

### DIFF
--- a/src/test/java/blackbox/slow/PoolIT.java
+++ b/src/test/java/blackbox/slow/PoolIT.java
@@ -270,7 +270,10 @@ abstract class PoolIT {
       semaphore.acquire();
     }
 
-    assertThat(allocator.getDeallocations()).isEqualTo(subList);
+    List<GenericPoolable> deallocations = allocator.getDeallocations();
+    synchronized (deallocations) {
+      assertThat(deallocations).isEqualTo(subList);
+    }
 
     objs.get(startingSize - 1).release();
     assertTrue(completionFuture.get(1, TimeUnit.MINUTES), "shutdown timeout elapsed");

--- a/src/test/java/blackbox/slow/ThreadBasedPoolIT.java
+++ b/src/test/java/blackbox/slow/ThreadBasedPoolIT.java
@@ -126,7 +126,10 @@ abstract class ThreadBasedPoolIT extends PoolIT {
       semaphore.acquire();
     }
 
-    assertThat(allocator.getDeallocations()).containsExactlyElementsOf(subList);
+    List<GenericPoolable> deallocations = allocator.getDeallocations();
+    synchronized (deallocations) {
+      assertThat(deallocations).containsExactlyElementsOf(subList);
+    }
 
     objs.get(startingSize - 1).release();
   }


### PR DESCRIPTION
The test counting allocators use synchronized lists, but their iterators are not thread-safe.