### PR TITLE
Add a SlotInfo.getCreatedNanoTime and fix flaky test

### DIFF
--- a/src/main/java/stormpot/BSlot.java
+++ b/src/main/java/stormpot/BSlot.java
@@ -104,6 +104,11 @@ final class BSlot<T extends Poolable>
   }
 
   @Override
+  public long getCreatedNanoTime() {
+    return createdNanos;
+  }
+
+  @Override
   public long getClaimCount() {
     return claims;
   }

--- a/src/main/java/stormpot/SlotInfo.java
+++ b/src/main/java/stormpot/SlotInfo.java
@@ -32,6 +32,15 @@ public interface SlotInfo<T extends Poolable> {
   long getAgeMillis();
 
   /**
+   * Get the approximate {@link System#nanoTime()} timestamp for when the object
+   * was allocated.
+   * @return The object allocation {@link System#nanoTime()} timestamp.
+   */
+  default long getCreatedNanoTime() {
+    return 0;
+  }
+
+  /**
    * Get the number of times the object has been claimed since it was
    * allocated.
    * @return The objects claim count.


### PR DESCRIPTION
The flaky test was relying on overly precise SlotInfo.getAgeMillis, but it is not that uncommon for slots to age 100 milliseconds or more in the heat of a test. The SlotInfo.getCreatedNanoTime side-steps the racy check on age.