### PR TITLE
Add a PoolTap that support virtual threads

### DIFF
--- a/api-changes.json
+++ b/api-changes.json
@@ -27,150 +27,171 @@
           "code": "java.class.noLongerInheritsFromClass",
           "old": "class stormpot.Pool<T extends stormpot.Poolable>",
           "new": "interface stormpot.Pool<T extends stormpot.Poolable>",
-          "justification": "ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE"
+          "justification": "Major version change"
         },
         {
           "code": "java.class.kindChanged",
           "old": "class stormpot.Pool<T extends stormpot.Poolable>",
           "new": "interface stormpot.Pool<T extends stormpot.Poolable>",
-          "justification": "ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE"
+          "justification": "Major version change"
         },
         {
           "code": "java.method.nowAbstract",
           "old": "method stormpot.Pool<T> stormpot.PoolBuilder<T extends stormpot.Poolable>::build()",
           "new": "method stormpot.Pool<T> stormpot.PoolBuilder<T extends stormpot.Poolable>::build()",
-          "justification": "ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE"
+          "justification": "Major version change"
         },
         {
           "code": "java.method.nowAbstract",
           "old": "method stormpot.PoolBuilder<T> stormpot.PoolBuilder<T extends stormpot.Poolable>::clone()",
           "new": "method stormpot.PoolBuilder<T> stormpot.PoolBuilder<T extends stormpot.Poolable>::clone()",
-          "justification": "ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE"
+          "justification": "Major version change"
         },
         {
           "code": "java.method.nowAbstract",
           "old": "method stormpot.Allocator<T> stormpot.PoolBuilder<T extends stormpot.Poolable>::getAllocator()",
           "new": "method stormpot.Allocator<T> stormpot.PoolBuilder<T extends stormpot.Poolable>::getAllocator()",
-          "justification": "ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE"
+          "justification": "Major version change"
         },
         {
           "code": "java.method.nowAbstract",
           "old": "method int stormpot.PoolBuilder<T extends stormpot.Poolable>::getBackgroundExpirationCheckDelay()",
           "new": "method int stormpot.PoolBuilder<T extends stormpot.Poolable>::getBackgroundExpirationCheckDelay()",
-          "justification": "ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE"
+          "justification": "Major version change"
         },
         {
           "code": "java.method.nowAbstract",
           "old": "method stormpot.Expiration<? super T> stormpot.PoolBuilder<T extends stormpot.Poolable>::getExpiration()",
           "new": "method stormpot.Expiration<? super T> stormpot.PoolBuilder<T extends stormpot.Poolable>::getExpiration()",
-          "justification": "ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE"
+          "justification": "Major version change"
         },
         {
           "code": "java.method.nowAbstract",
           "old": "method stormpot.MetricsRecorder stormpot.PoolBuilder<T extends stormpot.Poolable>::getMetricsRecorder()",
           "new": "method stormpot.MetricsRecorder stormpot.PoolBuilder<T extends stormpot.Poolable>::getMetricsRecorder()",
-          "justification": "ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE"
+          "justification": "Major version change"
         },
         {
           "code": "java.method.nowAbstract",
           "old": "method stormpot.Reallocator<T> stormpot.PoolBuilder<T extends stormpot.Poolable>::getReallocator()",
           "new": "method stormpot.Reallocator<T> stormpot.PoolBuilder<T extends stormpot.Poolable>::getReallocator()",
-          "justification": "ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE"
+          "justification": "Major version change"
         },
         {
           "code": "java.method.nowAbstract",
           "old": "method int stormpot.PoolBuilder<T extends stormpot.Poolable>::getSize()",
           "new": "method int stormpot.PoolBuilder<T extends stormpot.Poolable>::getSize()",
-          "justification": "ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE"
+          "justification": "Major version change"
         },
         {
           "code": "java.method.nowAbstract",
           "old": "method java.util.concurrent.ThreadFactory stormpot.PoolBuilder<T extends stormpot.Poolable>::getThreadFactory()",
           "new": "method java.util.concurrent.ThreadFactory stormpot.PoolBuilder<T extends stormpot.Poolable>::getThreadFactory()",
-          "justification": "ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE"
+          "justification": "Major version change"
         },
         {
           "code": "java.method.nowAbstract",
           "old": "method boolean stormpot.PoolBuilder<T extends stormpot.Poolable>::isBackgroundExpirationEnabled()",
           "new": "method boolean stormpot.PoolBuilder<T extends stormpot.Poolable>::isBackgroundExpirationEnabled()",
-          "justification": "ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE"
+          "justification": "Major version change"
         },
         {
           "code": "java.method.nowAbstract",
           "old": "method boolean stormpot.PoolBuilder<T extends stormpot.Poolable>::isPreciseLeakDetectionEnabled()",
           "new": "method boolean stormpot.PoolBuilder<T extends stormpot.Poolable>::isPreciseLeakDetectionEnabled()",
-          "justification": "ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE"
+          "justification": "Major version change"
         },
         {
           "code": "java.method.nowAbstract",
           "old": "method <X extends stormpot.Poolable> stormpot.PoolBuilder<X> stormpot.PoolBuilder<T extends stormpot.Poolable>::setAllocator(stormpot.Allocator<X>)",
           "new": "method <X extends stormpot.Poolable> stormpot.PoolBuilder<X> stormpot.PoolBuilder<T extends stormpot.Poolable>::setAllocator(stormpot.Allocator<X>)",
-          "justification": "ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE"
+          "justification": "Major version change"
         },
         {
           "code": "java.method.nowAbstract",
           "old": "method stormpot.PoolBuilder<T> stormpot.PoolBuilder<T extends stormpot.Poolable>::setBackgroundExpirationCheckDelay(int)",
           "new": "method stormpot.PoolBuilder<T> stormpot.PoolBuilder<T extends stormpot.Poolable>::setBackgroundExpirationCheckDelay(int)",
-          "justification": "ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE"
+          "justification": "Major version change"
         },
         {
           "code": "java.method.nowAbstract",
           "old": "method stormpot.PoolBuilder<T> stormpot.PoolBuilder<T extends stormpot.Poolable>::setBackgroundExpirationEnabled(boolean)",
           "new": "method stormpot.PoolBuilder<T> stormpot.PoolBuilder<T extends stormpot.Poolable>::setBackgroundExpirationEnabled(boolean)",
-          "justification": "ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE"
+          "justification": "Major version change"
         },
         {
           "code": "java.method.nowAbstract",
           "old": "method stormpot.PoolBuilder<T> stormpot.PoolBuilder<T extends stormpot.Poolable>::setExpiration(stormpot.Expiration<? super T>)",
           "new": "method stormpot.PoolBuilder<T> stormpot.PoolBuilder<T extends stormpot.Poolable>::setExpiration(stormpot.Expiration<? super T>)",
-          "justification": "ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE"
+          "justification": "Major version change"
         },
         {
           "code": "java.method.nowAbstract",
           "old": "method stormpot.PoolBuilder<T> stormpot.PoolBuilder<T extends stormpot.Poolable>::setMetricsRecorder(stormpot.MetricsRecorder)",
           "new": "method stormpot.PoolBuilder<T> stormpot.PoolBuilder<T extends stormpot.Poolable>::setMetricsRecorder(stormpot.MetricsRecorder)",
-          "justification": "ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE"
+          "justification": "Major version change"
         },
         {
           "code": "java.method.nowAbstract",
           "old": "method stormpot.PoolBuilder<T> stormpot.PoolBuilder<T extends stormpot.Poolable>::setPreciseLeakDetectionEnabled(boolean)",
           "new": "method stormpot.PoolBuilder<T> stormpot.PoolBuilder<T extends stormpot.Poolable>::setPreciseLeakDetectionEnabled(boolean)",
-          "justification": "ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE"
+          "justification": "Major version change"
         },
         {
           "code": "java.method.nowAbstract",
           "old": "method stormpot.PoolBuilder<T> stormpot.PoolBuilder<T extends stormpot.Poolable>::setSize(int)",
           "new": "method stormpot.PoolBuilder<T> stormpot.PoolBuilder<T extends stormpot.Poolable>::setSize(int)",
-          "justification": "ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE"
+          "justification": "Major version change"
         },
         {
           "code": "java.method.nowAbstract",
           "old": "method stormpot.PoolBuilder<T> stormpot.PoolBuilder<T extends stormpot.Poolable>::setThreadFactory(java.util.concurrent.ThreadFactory)",
           "new": "method stormpot.PoolBuilder<T> stormpot.PoolBuilder<T extends stormpot.Poolable>::setThreadFactory(java.util.concurrent.ThreadFactory)",
-          "justification": "ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE"
+          "justification": "Major version change"
         },
         {
           "code": "java.class.kindChanged",
           "old": "class stormpot.PoolBuilder<T extends stormpot.Poolable>",
           "new": "interface stormpot.PoolBuilder<T extends stormpot.Poolable>",
-          "justification": "ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE"
+          "justification": "Major version change"
         },
         {
           "code": "java.class.nowAbstract",
           "old": "class stormpot.PoolBuilder<T extends stormpot.Poolable>",
           "new": "interface stormpot.PoolBuilder<T extends stormpot.Poolable>",
-          "justification": "ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE"
+          "justification": "Major version change"
         },
         {
           "code": "java.class.kindChanged",
           "old": "class stormpot.PoolTap<T extends stormpot.Poolable>",
           "new": "interface stormpot.PoolTap<T extends stormpot.Poolable>",
-          "justification": "ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE"
+          "justification": "Major version change"
         },
         {
           "code": "java.method.addedToInterface",
           "new": "method long stormpot.SlotInfo<T extends stormpot.Poolable>::getCreatedNanoTime()",
-          "justification": "ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE"
+          "justification": "Major version change"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method stormpot.PoolTap<T> stormpot.Pool<T extends stormpot.Poolable>::getSingleThreadedTap()",
+          "justification": "Major version change"
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method stormpot.PoolTap<T> stormpot.Pool<T extends stormpot.Poolable>::getThreadLocalTap()",
+          "justification": "Major version change"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method stormpot.PoolTap<T> stormpot.Pool<T extends stormpot.Poolable>::getVirtualThreadSafeTap()",
+          "justification": "Major version change"
+        },
+        {
+          "code": "java.method.nowAbstract",
+          "old": "method stormpot.PoolTap<T> stormpot.Pool<T extends stormpot.Poolable>::getThreadSafeTap()",
+          "new": "method stormpot.PoolTap<T> stormpot.Pool<T extends stormpot.Poolable>::getThreadSafeTap()",
+          "justification": "Major version change"
         }
       ]
     }

--- a/src/main/java/stormpot/Pool.java
+++ b/src/main/java/stormpot/Pool.java
@@ -275,23 +275,25 @@ public interface Pool<T extends Poolable> extends PoolTap<T> {
   /**
    * Get a thread-safe {@link PoolTap} implementation for this pool, which can
    * be freely shared among multiple threads.
+   * <p>
+   * If the pool tap will be accessed by {@linkplain Thread#isVirtual() virtual threads},
+   * then {@link #getVirtualThreadSafeTap()} should be used instead.
+   *
    * @return A thread-safe {@link PoolTap}.
    */
-  default PoolTap<T> getThreadSafeTap() {
-    // We use the anonymous inner class to enforce encapsulation, which is
-    // probably the only reason anyone would wan to use this.
-    return new PoolTap<>() {
-      @Override
-      public T claim(Timeout timeout) throws PoolException, InterruptedException {
-        return Pool.this.claim(timeout);
-      }
+  PoolTap<T> getThreadSafeTap();
 
-      @Override
-      public T tryClaim() {
-        return Pool.this.tryClaim();
-      }
-    };
-  }
+  /**
+   * Get a thread-safe {@link PoolTap} implementation for this pool, which can
+   * be freely shared among multiple threads, including {@linkplain Thread#isVirtual() virtual threads}.
+   * <p>
+   * The implementation of this {@link PoolTap} avoids the use of {@link ThreadLocal} variables,
+   * locking mechanisms, and other API calls that are poorly supported by, or disruptive to,
+   * virtual threads.
+   *
+   * @return A thread-safe {@link PoolTap}.
+   */
+  PoolTap<T> getVirtualThreadSafeTap();
 
   /**
    * Get a {@link PoolTap} that only support access by one thread at a time.
@@ -307,5 +309,5 @@ public interface Pool<T extends Poolable> extends PoolTap<T> {
    *
    * @return A thread-local {@link PoolTap}.
    */
-  PoolTap<T> getThreadLocalTap();
+  PoolTap<T> getSingleThreadedTap();
 }

--- a/src/main/java/stormpot/internal/BSlot.java
+++ b/src/main/java/stormpot/internal/BSlot.java
@@ -188,7 +188,8 @@ abstract class PaddedAtomicInteger extends Padding1 {
   static {
     try {
       MethodHandles.Lookup lookup = MethodHandles.lookup();
-      STATE = lookup.findVarHandle(PaddedAtomicInteger.class, "state", int.class);
+      STATE = lookup.findVarHandle(PaddedAtomicInteger.class, "state", int.class)
+              .withInvokeExactBehavior();
     } catch (NoSuchFieldException | IllegalAccessException e) {
       throw new AssertionError("Failed to initialise the state VarHandle.", e);
     }

--- a/src/main/java/stormpot/internal/BlazePoolSingleThreadedTap.java
+++ b/src/main/java/stormpot/internal/BlazePoolSingleThreadedTap.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2011-2024 Chris Vest (mr.chrisvest@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package stormpot.internal;
+
+import stormpot.PoolException;
+import stormpot.PoolTap;
+import stormpot.Poolable;
+import stormpot.Timeout;
+
+/**
+ * The claim method in this pool tap follows the same idea as the thread-local
+ * caching and TLR-claiming in the pool itself. However, instead of relying on
+ * a thread-local for the object caching, we instead directly use a field of
+ * the pool tap instance.
+ * <p>
+ * This has two advantages: 1) a field load is faster than a thread-local
+ * lookup, and 2) there is no thread-local "leaking" or contamination.
+ *
+ * @param <T> The poolable type.
+ */
+public final class BlazePoolSingleThreadedTap<T extends Poolable> implements PoolTap<T> {
+  private final BlazePool<T> pool;
+  private final BSlotCache<T> cache = new BSlotCache<>();
+
+  BlazePoolSingleThreadedTap(BlazePool<T> pool) {
+    this.pool = pool;
+  }
+
+  @Override
+  public T claim(Timeout timeout) throws PoolException, InterruptedException {
+    return pool.claim(timeout, cache);
+  }
+
+  @Override
+  public T tryClaim() {
+    return pool.tryClaim(cache);
+  }
+}

--- a/src/main/java/stormpot/internal/BlazePoolThreadSafeTap.java
+++ b/src/main/java/stormpot/internal/BlazePoolThreadSafeTap.java
@@ -21,31 +21,25 @@ import stormpot.Poolable;
 import stormpot.Timeout;
 
 /**
- * The claim method in this pool tap follows the same idea as the thread-local
- * caching and TLR-claiming in the pool itself. However, instead of relying on
- * a thread-local for the object caching, we instead directly use a field of
- * the pool tap instance.
- * <p>
- * This has two advantages: 1) a field load is faster than a thread-local
- * lookup, and 2) there is no thread-local "leaking" or contamination.
+ * The claim method in this pool tap offers similar thread-safety and
+ * performance to the default thread-safe pool tap.
  *
  * @param <T> The poolable type.
  */
-public final class BlazePoolThreadLocalTap<T extends Poolable> implements PoolTap<T> {
+public final class BlazePoolThreadSafeTap<T extends Poolable> implements PoolTap<T> {
   private final BlazePool<T> pool;
-  private final BSlotCache<T> cache = new BSlotCache<>();
 
-  BlazePoolThreadLocalTap(BlazePool<T> pool) {
+  public BlazePoolThreadSafeTap(BlazePool<T> pool) {
     this.pool = pool;
   }
 
   @Override
   public T claim(Timeout timeout) throws PoolException, InterruptedException {
-    return pool.claim(timeout, cache);
+    return pool.claim(timeout);
   }
 
   @Override
-  public T tryClaim() {
-    return pool.tryClaim(cache);
+  public T tryClaim() throws PoolException {
+    return pool.tryClaim();
   }
 }

--- a/src/main/java/stormpot/internal/BlazePoolVirtualThreadSafeTap.java
+++ b/src/main/java/stormpot/internal/BlazePoolVirtualThreadSafeTap.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright © 2011-2024 Chris Vest (mr.chrisvest@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package stormpot.internal;
+
+import stormpot.PoolException;
+import stormpot.PoolTap;
+import stormpot.Poolable;
+import stormpot.Timeout;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+
+/**
+ * The claim method in this pool tap offers similar thread-safety and
+ * performance to the default thread-safe pool tap, but without the use of
+ * {@link ThreadLocal}.
+ * <p>
+ * This allows the pool tap to be used by virtual threads, without risking the
+ * undue memory overhead of thousands or millions of thread-locals.
+ *
+ * @param <T> The poolable type.
+ */
+public final class BlazePoolVirtualThreadSafeTap<T extends Poolable> implements PoolTap<T> {
+  private static final VarHandle ARRAY_VH;
+  private static final VarHandle STRIPES_VH;
+
+  static {
+    ARRAY_VH = MethodHandles.arrayElementVarHandle(BSlotCache[].class)
+            .withInvokeExactBehavior();
+    assert ARRAY_VH.hasInvokeExactBehavior();
+    try {
+      STRIPES_VH = MethodHandles.lookup().findVarHandle(
+              BlazePoolVirtualThreadSafeTap.class, "stripes", BSlotCache[].class)
+              .withInvokeExactBehavior();
+      assert STRIPES_VH.hasInvokeExactBehavior();
+    } catch (Exception e) {
+      throw new ExceptionInInitializerError(e);
+    }
+  }
+
+  private static final int ARRAY_SIZE = 0x80; // 128
+  private static final int ARRAY_MASK = 0x7F;
+
+  private final BlazePool<T> pool;
+  @SuppressWarnings("unused") // Accessed via VarHandle
+  private BSlotCache<T>[] stripes;
+
+  BlazePoolVirtualThreadSafeTap(BlazePool<T> pool) {
+    this.pool = pool;
+  }
+
+  @Override
+  public T claim(Timeout timeout) throws PoolException, InterruptedException {
+    BSlotCache<T>[] stripes = getStripes();
+    long threadId = Thread.currentThread().threadId();
+    T obj = tryTlrClaim(threadId, stripes);
+    if (obj != null) {
+      return obj;
+    }
+    int index = (int) (threadId & ARRAY_MASK);
+    BSlotCache<T> cache = stripes[index];
+    assert cache != null;
+    return pool.claim(timeout, cache);
+  }
+
+  private BSlotCache<T>[] getStripes() {
+    BSlotCache<T>[] stripes = this.stripes;
+    if (stripes == null) {
+      stripes = createStripes();
+    }
+    return stripes;
+  }
+
+  @SuppressWarnings("unchecked")
+  private BSlotCache<T>[] createStripes() {
+    BSlotCache<T>[] stripes, witness;
+    stripes = (BSlotCache<T>[]) STRIPES_VH.getVolatile(this);
+    if (stripes == null) {
+      stripes = new BSlotCache[ARRAY_SIZE];
+      witness = (BSlotCache<T>[]) STRIPES_VH.compareAndExchange(this, (BSlotCache<T>[]) null, stripes);
+      if (witness != null) {
+        stripes = witness;
+      }
+    }
+    return stripes;
+  }
+
+  private T tryTlrClaim(long threadId, BSlotCache<T>[] stripes) {
+    for (int i = 0; i < 4; i++) {
+      int index = (int) (threadId + i & ARRAY_MASK);
+      BSlotCache<T> cache = stripes[index];
+      if (cache == null) {
+        cache = createCacheSlot(stripes, index);
+      }
+      T obj = pool.tlrClaim(cache);
+      if (obj != null) {
+        return obj;
+      }
+    }
+    return null;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T extends Poolable> BSlotCache<T> createCacheSlot(BSlotCache<T>[] stripes, int index) {
+    BSlotCache<T> cache = new BSlotCache<>();
+    BSlotCache<T> tmp = (BSlotCache<T>) ARRAY_VH.compareAndExchange(stripes, index, (BSlotCache<T>) null, cache);
+    if (tmp != null) {
+      cache = tmp;
+    }
+    return cache;
+  }
+
+  @Override
+  public T tryClaim() throws PoolException {
+    BSlotCache<T>[] stripes = getStripes();
+    long threadId = Thread.currentThread().threadId();
+    T obj = tryTlrClaim(threadId, stripes);
+    if (obj != null) {
+      return obj;
+    }
+    int index = (int) (threadId & ARRAY_MASK);
+    BSlotCache<T> cache = stripes[index];
+    assert cache != null;
+    return pool.tryClaim(cache);
+  }
+}

--- a/src/main/java/stormpot/internal/InlineAllocationController.java
+++ b/src/main/java/stormpot/internal/InlineAllocationController.java
@@ -40,9 +40,12 @@ public final class InlineAllocationController<T extends Poolable> extends Alloca
     try {
       MethodHandles.Lookup lookup = MethodHandles.lookup();
       Class<?> receiver = InlineAllocationController.class;
-      SIZE = lookup.findVarHandle(receiver, "size", int.class);
-      ALLOC_COUNT = lookup.findVarHandle(receiver, "allocationCount", long.class);
-      FAILED_ALLOC_COUNT = lookup.findVarHandle(receiver, "failedAllocationCount", long.class);
+      SIZE = lookup.findVarHandle(receiver, "size", int.class)
+              .withInvokeExactBehavior();
+      ALLOC_COUNT = lookup.findVarHandle(receiver, "allocationCount", long.class)
+              .withInvokeExactBehavior();
+      FAILED_ALLOC_COUNT = lookup.findVarHandle(receiver, "failedAllocationCount", long.class)
+              .withInvokeExactBehavior();
     } catch (Exception e) {
       throw new LinkageError("Failed to create VarHandle.", e);
     }
@@ -253,7 +256,7 @@ public final class InlineAllocationController<T extends Poolable> extends Alloca
       poisonedSlots.getAndIncrement();
       slot.poison = e;
     }
-    SIZE.getAndAdd(this, 1);
+    int ignore = (int) SIZE.getAndAdd(this, 1);
     publishSlot(slot, success, NanoClock.nanoTime());
   }
 
@@ -271,9 +274,9 @@ public final class InlineAllocationController<T extends Poolable> extends Alloca
 
   private void incrementAllocationCounts(boolean success) {
     if (success) {
-      ALLOC_COUNT.getAndAdd(this, 1);
+      long ignore = (long) ALLOC_COUNT.getAndAdd(this, 1L);
     } else {
-      FAILED_ALLOC_COUNT.getAndAdd(this, 1);
+      long ignore = (long) FAILED_ALLOC_COUNT.getAndAdd(this, 1L);
     }
   }
 
@@ -311,7 +314,7 @@ public final class InlineAllocationController<T extends Poolable> extends Alloca
   }
 
   private void dealloc(BSlot<T> slot) {
-    SIZE.getAndAdd(this, -1);
+    int ignore = (int) SIZE.getAndAdd(this, -1);
     deallocSlot(slot);
   }
 

--- a/src/main/java/stormpot/internal/PoisonException.java
+++ b/src/main/java/stormpot/internal/PoisonException.java
@@ -15,7 +15,12 @@
  */
 package stormpot.internal;
 
-public class PoisonException extends Exception {
+import java.io.Serial;
+
+public final class PoisonException extends Exception {
+  @Serial
+  private static final long serialVersionUID = 5196724916292026430L;
+
   public PoisonException(String message) {
     super(message, null, false, false);
   }

--- a/src/main/resources/META-INF/native-image/com.github.chrisvest/stormpot/native-image.properties
+++ b/src/main/resources/META-INF/native-image/com.github.chrisvest/stormpot/native-image.properties
@@ -1,2 +1,2 @@
 #Temporary solution. May be removed when this issue is solved: https://github.com/oracle/graal/issues/3028
-Args = --initialize-at-build-time=stormpot.PaddedAtomicInteger
+Args = --initialize-at-build-time=stormpot.internal.PaddedAtomicInteger,stormpot.internal.BlazePoolVirtualThreadSafeTap

--- a/src/test/java/stormpot/tests/WhiteboxPoolTest.java
+++ b/src/test/java/stormpot/tests/WhiteboxPoolTest.java
@@ -55,8 +55,18 @@ class WhiteboxPoolTest {
       }
 
       @Override
-      public PoolTap<Poolable> getThreadLocalTap() {
-        return null;
+      public PoolTap<Poolable> getThreadSafeTap() {
+        return this::claim;
+      }
+
+      @Override
+      public PoolTap<Poolable> getVirtualThreadSafeTap() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public PoolTap<Poolable> getSingleThreadedTap() {
+        throw new UnsupportedOperationException();
       }
 
       @Override

--- a/src/test/java/stormpot/tests/blackbox/DefaultPoolTest.java
+++ b/src/test/java/stormpot/tests/blackbox/DefaultPoolTest.java
@@ -15,14 +15,14 @@
  */
 package stormpot.tests.blackbox;
 
-import testkits.AlloKit;
-import testkits.GenericPoolable;
+import stormpot.Allocator;
+import stormpot.Poolable;
 import stormpot.Pool;
 import stormpot.PoolBuilder;
 
 class DefaultPoolTest extends ThreadBasedPoolTest {
   @Override
-  protected PoolBuilder<GenericPoolable> createInitialPoolBuilder(AlloKit.CountingAllocator allocator) {
+  protected <T extends Poolable> PoolBuilder<T> createInitialPoolBuilder(Allocator<T> allocator) {
     return Pool.from(allocator);
   }
 }

--- a/src/test/java/stormpot/tests/blackbox/DirectPoolTest.java
+++ b/src/test/java/stormpot/tests/blackbox/DirectPoolTest.java
@@ -30,7 +30,8 @@ class DirectPoolTest extends AbstractPoolTest<Pooled<String>> {
   private void createPool(String... objects) {
     pool = Pool.of(objects);
     threadSafeTap = pool.getThreadSafeTap();
-    threadLocalTap = pool.getThreadLocalTap();
+    threadVirtualTap = pool.getVirtualThreadSafeTap();
+    threadLocalTap = pool.getSingleThreadedTap();
   }
 
   @Override

--- a/src/test/java/stormpot/tests/blackbox/InlinePoolTest.java
+++ b/src/test/java/stormpot/tests/blackbox/InlinePoolTest.java
@@ -16,8 +16,8 @@
 package stormpot.tests.blackbox;
 
 import org.junit.jupiter.api.Test;
-import testkits.AlloKit.CountingAllocator;
-import testkits.GenericPoolable;
+import stormpot.Allocator;
+import stormpot.Poolable;
 import stormpot.Pool;
 import stormpot.PoolBuilder;
 
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class InlinePoolTest extends AllocatorBasedPoolTest {
   @Override
-  protected PoolBuilder<GenericPoolable> createInitialPoolBuilder(CountingAllocator allocator) {
+  protected <T extends Poolable> PoolBuilder<T> createInitialPoolBuilder(Allocator<T> allocator) {
     return Pool.fromInline(allocator);
   }
 

--- a/src/test/java/stormpot/tests/blackbox/Taps.java
+++ b/src/test/java/stormpot/tests/blackbox/Taps.java
@@ -32,6 +32,12 @@ enum Taps {
       return test.threadSafeTap;
     }
   },
+  THREAD_VIRTUAL {
+    @Override
+    <T extends Poolable> PoolTap<T> get(AbstractPoolTest<T> test) {
+      return test.threadVirtualTap;
+    }
+  },
   THREAD_LOCAL {
     @Override
     <T extends Poolable> PoolTap<T> get(AbstractPoolTest<T> test) {

--- a/src/test/java/stormpot/tests/blackbox/ThreadedPoolTest.java
+++ b/src/test/java/stormpot/tests/blackbox/ThreadedPoolTest.java
@@ -15,14 +15,14 @@
  */
 package stormpot.tests.blackbox;
 
-import testkits.AlloKit;
-import testkits.GenericPoolable;
+import stormpot.Allocator;
+import stormpot.Poolable;
 import stormpot.Pool;
 import stormpot.PoolBuilder;
 
 public class ThreadedPoolTest extends ThreadBasedPoolTest {
   @Override
-  protected PoolBuilder<GenericPoolable> createInitialPoolBuilder(AlloKit.CountingAllocator allocator) {
+  protected <T extends Poolable> PoolBuilder<T> createInitialPoolBuilder(Allocator<T> allocator) {
     return Pool.fromThreaded(allocator);
   }
 }


### PR DESCRIPTION
Virtual threads need to avoid things like ThreadLocal variables, synchronized methods or blocks, and other poorly supported APIs. This adds a PoolTap implementation that relies on striping BSlotCaches based on the thread-id, to spread contention when TLR-claiming objects.