### PR TITLE
Use opaque instead of volatile access to the BlazePool.shutdown field

### DIFF
--- a/src/main/resources/META-INF/native-image/com.github.chrisvest/stormpot/native-image.properties
+++ b/src/main/resources/META-INF/native-image/com.github.chrisvest/stormpot/native-image.properties
@@ -1,2 +1,2 @@
 #Temporary solution. May be removed when this issue is solved: https://github.com/oracle/graal/issues/3028
-Args = --initialize-at-build-time=stormpot.internal.PaddedAtomicInteger,stormpot.internal.BlazePoolVirtualThreadSafeTap
+Args = --initialize-at-build-time=stormpot.internal.PaddedAtomicInteger,stormpot.internal.BlazePoolVirtualThreadSafeTap,stormpot.internal.BlazePool


### PR DESCRIPTION
Opaque access should in theory give the JIT compiler more freedom to optimize. Using opaque access means the memory operations will still be performed, instead of being maximally hoisted to a register, but it doesn't restrict the movement of other loads and stores like the volatile accesses do.