### PR TITLE
Remove SlotInfo.getClaimCount

### DIFF
--- a/api-changes.json
+++ b/api-changes.json
@@ -204,6 +204,12 @@
           "code": "java.method.removed",
           "old": "method long stormpot.Timeout::getTimeLeft(long)",
           "justification": "Major version change"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method long stormpot.SlotInfo<T extends stormpot.Poolable>::getClaimCount()",
+          "justification": "Major version change"
         }
       ]
     }

--- a/src/main/java/stormpot/SlotInfo.java
+++ b/src/main/java/stormpot/SlotInfo.java
@@ -39,13 +39,6 @@ public interface SlotInfo<T extends Poolable> {
   long getCreatedNanoTime();
 
   /**
-   * Get the number of times the object has been claimed since it was
-   * allocated.
-   * @return The objects claim count.
-   */
-  long getClaimCount();
-
-  /**
    * Get the Poolable object represented by this SlotInfo instance.
    * <p>
    * WARNING: Do not {@link Poolable#release() release()}

--- a/src/main/java/stormpot/internal/BAllocThread.java
+++ b/src/main/java/stormpot/internal/BAllocThread.java
@@ -306,7 +306,6 @@ public final class BAllocThread<T extends Poolable> implements Runnable {
 
   private void resetSlot(BSlot<T> slot, long now) {
     slot.createdNanos = now;
-    slot.claims = 0;
     slot.stamp = 0;
     slot.dead2live();
   }

--- a/src/main/java/stormpot/internal/BSlot.java
+++ b/src/main/java/stormpot/internal/BSlot.java
@@ -115,11 +115,6 @@ public final class BSlot<T extends Poolable>
   }
 
   @Override
-  public long getClaimCount() {
-    return claims;
-  }
-
-  @Override
   public T getPoolable() {
     return obj;
   }
@@ -139,10 +134,6 @@ public final class BSlot<T extends Poolable>
   boolean isClaimedOrThreadLocal() {
     int state = get();
     return state == CLAIMED || state == TLR_CLAIMED;
-  }
-
-  void incrementClaims() {
-    claims++;
   }
 
   @Override
@@ -224,7 +215,6 @@ abstract class BSlotColdFields<T extends Poolable> extends PaddedAtomicInteger i
   public T obj;
   public Exception poison;
   public Reference<Object> leakCheck; // Used by PreciseLeakDetector
-  long claims;
 
   BSlotColdFields(
       int state,

--- a/src/main/java/stormpot/internal/BSlot.java
+++ b/src/main/java/stormpot/internal/BSlot.java
@@ -171,6 +171,10 @@ abstract class Padding1 {
   private byte p1;
   private byte p2;
   private byte p3;
+  private byte p4;
+  private byte p5;
+  private byte p6;
+  private byte p7;
 }
 
 abstract class PaddedAtomicInteger extends Padding1 {

--- a/src/main/java/stormpot/internal/BlazePool.java
+++ b/src/main/java/stormpot/internal/BlazePool.java
@@ -148,7 +148,6 @@ public final class BlazePool<T extends Poolable> implements Pool<T>, ManagedPool
       // had expired, and throw it in the dead queue, causing a claimed
       // Poolable to be deallocated before it is released.
       if (isValid(slot, cache, true)) {
-        slot.incrementClaims();
         return slot.obj;
       }
       // We managed to tlr-claim the slot, but it turned out to be no good.
@@ -180,7 +179,6 @@ public final class BlazePool<T extends Poolable> implements Pool<T>, ManagedPool
         return null;
       } else if (slot.live2claim()) {
         if (isValid(slot, cache, false)) {
-          slot.incrementClaims();
           cache.slot = slot;
           return slot.obj;
         }
@@ -210,7 +208,6 @@ public final class BlazePool<T extends Poolable> implements Pool<T>, ManagedPool
         disregardPile.refill();
       } else if (slot.live2claim()) {
         if (isValid(slot, cache, false)) {
-          slot.incrementClaims();
           cache.slot = slot;
           return slot.obj;
         }

--- a/src/main/java/stormpot/internal/InlineAllocationController.java
+++ b/src/main/java/stormpot/internal/InlineAllocationController.java
@@ -282,7 +282,6 @@ public final class InlineAllocationController<T extends Poolable> extends Alloca
 
   private void resetSlot(BSlot<T> slot, long now) {
     slot.createdNanos = now;
-    slot.claims = 0;
     slot.stamp = 0;
     slot.dead2live();
   }

--- a/src/test/java/testkits/ExpireKit.java
+++ b/src/test/java/testkits/ExpireKit.java
@@ -130,8 +130,4 @@ public class ExpireKit {
   public static SlotInfoCapture $poolable(AtomicReference<Poolable> ref) {
     return info -> ref.set(info.getPoolable());
   }
-
-  public static SlotInfoCapture $claimCount(AtomicLong count) {
-    return info -> count.set(info.getClaimCount());
-  }
 }

--- a/src/test/java/testkits/SlotInfoStub.java
+++ b/src/test/java/testkits/SlotInfoStub.java
@@ -43,11 +43,6 @@ public class SlotInfoStub implements SlotInfo<GenericPoolable> {
   }
 
   @Override
-  public long getClaimCount() {
-    return 0;
-  }
-
-  @Override
   public GenericPoolable getPoolable() {
     return null;
   }


### PR DESCRIPTION
This is a field that require a memory store in the hot code path, and a search on GitHub reveals no usages at all.