### PR TITLE
Marginally improve the access spread in BlazePoolVirtualThreadSafeTap

### DIFF
--- a/benchmarks/src/main/java/stormpot/benchmarks/ClaimRelease.java
+++ b/benchmarks/src/main/java/stormpot/benchmarks/ClaimRelease.java
@@ -22,18 +22,13 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Threads;
-import org.openjdk.jmh.annotations.Warmup;
-import stormpot.Allocator;
-import stormpot.BasePoolable;
 import stormpot.Expiration;
 import stormpot.Pool;
 import stormpot.PoolTap;
-import stormpot.Slot;
 import stormpot.Timeout;
 
 import java.util.concurrent.TimeUnit;
 
-@Warmup(iterations = 30)
 @Threads(12)
 @State(Scope.Benchmark)
 public class ClaimRelease {
@@ -85,22 +80,5 @@ public class ClaimRelease {
   @Benchmark
   public void sequential(PerThread state) throws InterruptedException {
     state.sequential.claim(timeout).release();
-  }
-}
-
-class GenericAllocator implements Allocator<GenericPoolable> {
-  @Override
-  public GenericPoolable allocate(Slot slot) {
-    return new GenericPoolable(slot);
-  }
-
-  @Override
-  public void deallocate(GenericPoolable genericPoolable) {
-  }
-}
-
-class GenericPoolable extends BasePoolable {
-  public GenericPoolable(Slot slot) {
-    super(slot);
   }
 }

--- a/benchmarks/src/main/java/stormpot/benchmarks/GenericAllocator.java
+++ b/benchmarks/src/main/java/stormpot/benchmarks/GenericAllocator.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2011-2024 Chris Vest (mr.chrisvest@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package stormpot.benchmarks;
+
+import stormpot.Allocator;
+import stormpot.Slot;
+
+class GenericAllocator implements Allocator<GenericPoolable> {
+  @Override
+  public GenericPoolable allocate(Slot slot) {
+    return new GenericPoolable(slot);
+  }
+
+  @Override
+  public void deallocate(GenericPoolable genericPoolable) {
+  }
+}

--- a/benchmarks/src/main/java/stormpot/benchmarks/GenericPoolable.java
+++ b/benchmarks/src/main/java/stormpot/benchmarks/GenericPoolable.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2011-2024 Chris Vest (mr.chrisvest@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package stormpot.benchmarks;
+
+import stormpot.BasePoolable;
+import stormpot.Slot;
+
+class GenericPoolable extends BasePoolable {
+  public GenericPoolable(Slot slot) {
+    super(slot);
+  }
+}

--- a/src/main/java/stormpot/internal/BlazePoolVirtualThreadSafeTap.java
+++ b/src/main/java/stormpot/internal/BlazePoolVirtualThreadSafeTap.java
@@ -49,7 +49,7 @@ public final class BlazePoolVirtualThreadSafeTap<T extends Poolable> implements 
 
   @Override
   public T claim(Timeout timeout) throws PoolException, InterruptedException {
-    int threadId = (int) Thread.currentThread().threadId();
+    int threadId = getThreadId();
     T obj = tryTlrClaim(threadId, stripes);
     if (obj != null) {
       return obj;
@@ -58,6 +58,11 @@ public final class BlazePoolVirtualThreadSafeTap<T extends Poolable> implements 
     BSlotCache<T> cache = stripes[index];
     assert cache != null;
     return pool.claim(timeout, cache);
+  }
+
+  private static int getThreadId() {
+    long threadId = Thread.currentThread().threadId();
+    return (int) (threadId ^ threadId >> 7);
   }
 
   private T tryTlrClaim(int threadId, BSlotCache<T>[] stripes) {
@@ -75,7 +80,7 @@ public final class BlazePoolVirtualThreadSafeTap<T extends Poolable> implements 
 
   @Override
   public T tryClaim() throws PoolException {
-    int threadId = (int) Thread.currentThread().threadId();
+    int threadId = getThreadId();
     T obj = tryTlrClaim(threadId, stripes);
     if (obj != null) {
       return obj;


### PR DESCRIPTION
This should decrease the likelihood of two different threads converging on the same stripe indicies.