### PR TITLE
Add a setting to optimise for reduced memory usage

### DIFF
--- a/api-changes.json
+++ b/api-changes.json
@@ -210,6 +210,18 @@
           "code": "java.method.removed",
           "old": "method long stormpot.SlotInfo<T extends stormpot.Poolable>::getClaimCount()",
           "justification": "Major version change"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.addedToInterface",
+          "new": "method boolean stormpot.PoolBuilder<T extends stormpot.Poolable>::isOptimizeForReducedMemoryUsage()",
+          "justification": "Major version change"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.addedToInterface",
+          "new": "method stormpot.PoolBuilder<T> stormpot.PoolBuilder<T extends stormpot.Poolable>::setOptimizeForReducedMemoryUsage(boolean)",
+          "justification": "Major version change"
         }
       ]
     }

--- a/benchmarks/src/main/java/stormpot/benchmarks/ClaimRelease.java
+++ b/benchmarks/src/main/java/stormpot/benchmarks/ClaimRelease.java
@@ -45,6 +45,7 @@ public class ClaimRelease {
             .setExpiration(Expiration.never())
             .setBackgroundExpirationEnabled(false)
             .setPreciseLeakDetectionEnabled(false)
+            .setOptimizeForReducedMemoryUsage(false)
             .build();
   }
 

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -176,6 +176,21 @@ In this case, there is still a chance that the object may be returned, but if no
 Such a case will not be detected by the precise leak detector.
 
 While precise leak detection is able to detect leaks – and a leak is always a bug in user code – it is not able to _prevent_ the leaks.
-This means that if a leak has been observed, you know for sure that the shut down process will not terminate.
-The shut down process won't finish until all allocated objects has been deallocated; which will never happen because leaked objects will remain logically claimed for perpetuity.
-In such a case it's nice that the API for awaiting on the completion of the shut down process mandates a timeout, so there's no waiting forever.
+This means that if a leak has been observed, you know for sure that the shutdown process will not terminate.
+The shutdown process won't finish until all allocated objects has been deallocated; which will never happen because leaked objects will remain logically claimed for perpetuity.
+In such a case it's nice that the API for awaiting on the completion of the shutdown process mandates a timeout, so there's no waiting forever.
+
+=== Optimizing for Reduced Memory Usage
+
+Stormpot 4.0 introduces a setting to optimize the pool for either reduced memory usage, or peak performance.
+The default is to reduce memory usage, because the performance enhancements that otherwise get enabled only make sense in the most extreme, high performance and high concurrency use cases.
+
+What this setting does when you turn "reduce memory usage" _off_, is to add padding to every `Slot` object.
+This padding inflate the object size, such that no two slot objects will ever occupy the same _CPU cache line_.
+The slot objects control the state of what objects can be claim and which are in use.
+This state is the primary source of multithreaded contention in Stormpot.
+However, the CPU deal with contention in terms of its cache lines of memory, rather than objects.
+By keeping slot objects on separate cache lines, we avoid a phenomenon called _false sharing_ where contention bleeds between different objects that happen to share a cache line.
+
+Most systems are so large, and have so many objects, that false sharing have no discernible impact on performance.
+For this reason, Stormpot optimizes for reduced memory usage by default, and does _not_ add any padding to its slot objects.

--- a/pom.xml
+++ b/pom.xml
@@ -115,12 +115,6 @@
         <version>3.2.5</version>
         <configuration>
           <trimStackTrace>false</trimStackTrace>
-          <argLine>
-            @{argLine}
-            -Djdk.attach.allowAttachSelf
-            -Djol.magicFieldOffset=true
-            -XX:+EnableDynamicAgentLoading
-          </argLine>
         </configuration>
       </plugin>
       <plugin>
@@ -129,12 +123,6 @@
         <version>3.2.5</version>
         <configuration>
           <trimStackTrace>false</trimStackTrace>
-          <argLine>
-            @{argLine}
-            -Djdk.attach.allowAttachSelf
-            -Djol.magicFieldOffset=true
-            -XX:+EnableDynamicAgentLoading
-          </argLine>
         </configuration>
         <executions>
           <execution>
@@ -392,12 +380,6 @@
       <groupId>org.hdrhistogram</groupId>
       <artifactId>HdrHistogram</artifactId>
       <version>2.2.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.openjdk.jol</groupId>
-      <artifactId>jol-core</artifactId>
-      <version>0.17</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/stormpot/PoolBuilder.java
+++ b/src/main/java/stormpot/PoolBuilder.java
@@ -248,6 +248,31 @@ public sealed interface PoolBuilder<T extends Poolable>
   PoolBuilder<T> setBackgroundExpirationCheckDelay(int delay);
 
   /**
+   * Return whether Stormpot will prioritize minimizing its memory overhead over
+   * maximizing performance.
+   * <p>
+   * This is {@code true} by default, as the performance gains don't show except in
+   * intense and highly concurrent use cases.
+   *
+   * @return {@code true} for prioritizing memory usage over absolute performance,
+   * otherwise {@code false} for prioritizing performance at all costs.
+   */
+  boolean isOptimizeForReducedMemoryUsage();
+
+  /**
+   * Tell the pool to optimize for either low memory usage (when giving {@code true}),
+   * or maximal performance (when giving {@code false}).
+   * <p>
+   * This is {@code true} by default, and should only be set to {@code false} when the
+   * pool is expected to be "relatively small" and will experience an extremely high
+   * level of multithreaded access.
+   *
+   * @param reduceMemoryUsage whether to prioritize memory usage or performance.
+   * @return This {@code PoolBuilder} instance.
+   */
+  PoolBuilder<T> setOptimizeForReducedMemoryUsage(boolean reduceMemoryUsage);
+
+  /**
    * Returns a shallow copy of this {@code PoolBuilder} object.
    * @return A new {@code PoolBuilder} object of the exact same type as this one, with
    * identical values in all its fields.

--- a/src/main/java/stormpot/internal/BSlotCache.java
+++ b/src/main/java/stormpot/internal/BSlotCache.java
@@ -17,6 +17,6 @@ package stormpot.internal;
 
 import stormpot.Poolable;
 
-public final class BSlotCache<T extends Poolable> {
+public class BSlotCache<T extends Poolable> {
   BSlot<T> slot;
 }

--- a/src/main/java/stormpot/internal/BSlotCachePadded.java
+++ b/src/main/java/stormpot/internal/BSlotCachePadded.java
@@ -17,15 +17,20 @@ package stormpot.internal;
 
 import stormpot.Poolable;
 
-public final class ThreadLocalBSlotCache<T extends Poolable> extends ThreadLocal<BSlotCache<T>> {
-  private final boolean optimizeForMemory;
-
-  public ThreadLocalBSlotCache(boolean optimizeForMemory) {
-    this.optimizeForMemory = optimizeForMemory;
-  }
-
-  @Override
-  protected BSlotCache<T> initialValue() {
-    return optimizeForMemory ? new BSlotCache<>() : new BSlotCachePadded<>();
-  }
+@SuppressWarnings("unused")
+public class BSlotCachePadded<T extends Poolable> extends BSlotCache<T> {
+  private long p00;
+  private long p01;
+  private long p02;
+  private long p03;
+  private long p04;
+  private long p05;
+  private long p06;
+  private long p07;
+  private long p08;
+  private long p09;
+  private long p10;
+  private long p11;
+  private long p12;
+  private long p13;
 }

--- a/src/main/java/stormpot/internal/BSlotPadded.java
+++ b/src/main/java/stormpot/internal/BSlotPadded.java
@@ -17,15 +17,22 @@ package stormpot.internal;
 
 import stormpot.Poolable;
 
-public final class ThreadLocalBSlotCache<T extends Poolable> extends ThreadLocal<BSlotCache<T>> {
-  private final boolean optimizeForMemory;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 
-  public ThreadLocalBSlotCache(boolean optimizeForMemory) {
-    this.optimizeForMemory = optimizeForMemory;
-  }
+@SuppressWarnings("unused")
+public class BSlotPadded<T extends Poolable> extends BSlot<T> {
+  private long p00;
+  private long p01;
+  private long p02;
+  private long p03;
+  private long p04;
+  private long p05;
+  private long p06;
+  private long p07;
+  private long p08;
 
-  @Override
-  protected BSlotCache<T> initialValue() {
-    return optimizeForMemory ? new BSlotCache<>() : new BSlotCachePadded<>();
+  public BSlotPadded(BlockingQueue<BSlot<T>> live, AtomicInteger poisonedSlots) {
+    super(live, poisonedSlots);
   }
 }

--- a/src/main/java/stormpot/internal/BlazePoolVirtualThreadSafeTap.java
+++ b/src/main/java/stormpot/internal/BlazePoolVirtualThreadSafeTap.java
@@ -39,11 +39,11 @@ public final class BlazePoolVirtualThreadSafeTap<T extends Poolable> implements 
   private final BSlotCache<T>[] stripes;
 
   @SuppressWarnings("unchecked")
-  BlazePoolVirtualThreadSafeTap(BlazePool<T> pool) {
+  BlazePoolVirtualThreadSafeTap(BlazePool<T> pool, boolean optimizeForMemory) {
     this.pool = pool;
     stripes = new BSlotCache[ARRAY_SIZE];
     for (int i = 0; i < ARRAY_SIZE; i++) {
-      stripes[i] = new BSlotCache<>();
+      stripes[i] = optimizeForMemory ? new BSlotCache<>() : new BSlotCachePadded<>();
     }
   }
 

--- a/src/main/java/stormpot/internal/DirectAllocationController.java
+++ b/src/main/java/stormpot/internal/DirectAllocationController.java
@@ -44,8 +44,10 @@ public final class DirectAllocationController<T extends Poolable> extends Alloca
     this.size = builder.getSize();
     poisonedSlots = new AtomicInteger();
     Allocator<T> allocator = builder.getAllocator();
+    boolean optimizeForMemory = builder.isOptimizeForReducedMemoryUsage();
     for (int i = 0; i < size; i++) {
-      BSlot<T> slot = new BSlot<>(live, poisonedSlots);
+      BSlot<T> slot = optimizeForMemory ?
+              new BSlot<>(live, poisonedSlots) : new BSlotPadded<>(live, poisonedSlots);
       try {
         slot.obj = allocator.allocate(slot);
         slot.createdNanos = System.nanoTime();

--- a/src/main/java/stormpot/internal/PoolBuilderDefaults.java
+++ b/src/main/java/stormpot/internal/PoolBuilderDefaults.java
@@ -26,17 +26,20 @@ public final class PoolBuilderDefaults {
   public final boolean preciseLeakDetectionEnabled;
   public final boolean backgroundExpirationEnabled;
   public final int backgroundExpirationCheckDelay;
+  public final boolean optimizeForMemory;
 
   public PoolBuilderDefaults(
       Expiration<Poolable> expiration,
       ThreadFactory threadFactory,
       boolean preciseLeakDetectionEnabled,
       boolean backgroundExpirationEnabled,
-      int backgroundExpirationCheckDelay) {
+      int backgroundExpirationCheckDelay,
+      boolean optimizeForMemory) {
     this.expiration = expiration;
     this.threadFactory = threadFactory;
     this.preciseLeakDetectionEnabled = preciseLeakDetectionEnabled;
     this.backgroundExpirationEnabled = backgroundExpirationEnabled;
     this.backgroundExpirationCheckDelay = backgroundExpirationCheckDelay;
+    this.optimizeForMemory = optimizeForMemory;
   }
 }

--- a/src/main/java/stormpot/internal/PoolBuilderImpl.java
+++ b/src/main/java/stormpot/internal/PoolBuilderImpl.java
@@ -41,9 +41,9 @@ public final class PoolBuilderImpl<T extends Poolable> implements PoolBuilder<T>
           .factory();
 
   public static final Map<AllocationProcessMode, PoolBuilderDefaults> DEFAULTS = Map.of(
-      THREADED, new PoolBuilderDefaults(after(8, 10, MINUTES), THREAD_FACTORY, true, true, 1000),
-      INLINE, new PoolBuilderDefaults(after(8, 10, MINUTES), THREAD_FACTORY, true, false, 0),
-      DIRECT, new PoolBuilderDefaults(never(), THREAD_FACTORY, false, false, 0)
+      THREADED, new PoolBuilderDefaults(after(8, 10, MINUTES), THREAD_FACTORY, true, true, 1000, true),
+      INLINE, new PoolBuilderDefaults(after(8, 10, MINUTES), THREAD_FACTORY, true, false, 0, true),
+      DIRECT, new PoolBuilderDefaults(never(), THREAD_FACTORY, false, false, 0, true)
   );
 
   public static final Map<AllocationProcessMode, PoolBuilderPermissions> PERMISSIONS = Map.of(
@@ -62,6 +62,7 @@ public final class PoolBuilderImpl<T extends Poolable> implements PoolBuilder<T>
   private boolean preciseLeakDetectionEnabled;
   private boolean backgroundExpirationEnabled;
   private int backgroundExpirationCheckDelay;
+  private boolean optimizeForMemory;
 
   /**
    * Build a new empty {@code PoolBuilder} object.
@@ -78,6 +79,7 @@ public final class PoolBuilderImpl<T extends Poolable> implements PoolBuilder<T>
     this.preciseLeakDetectionEnabled = defaults.preciseLeakDetectionEnabled;
     this.backgroundExpirationEnabled = defaults.backgroundExpirationEnabled;
     this.backgroundExpirationCheckDelay = defaults.backgroundExpirationCheckDelay;
+    this.optimizeForMemory = defaults.optimizeForMemory;
   }
 
   @Override
@@ -190,6 +192,17 @@ public final class PoolBuilderImpl<T extends Poolable> implements PoolBuilder<T>
       throw new IllegalArgumentException("Background expiration check delay cannot be negative.");
     }
     backgroundExpirationCheckDelay = delay;
+    return this;
+  }
+
+  @Override
+  public synchronized boolean isOptimizeForReducedMemoryUsage() {
+    return optimizeForMemory;
+  }
+
+  @Override
+  public synchronized PoolBuilder<T> setOptimizeForReducedMemoryUsage(boolean reduceMemoryUsage) {
+    this.optimizeForMemory = reduceMemoryUsage;
     return this;
   }
 

--- a/src/main/resources/META-INF/native-image/com.github.chrisvest/stormpot/native-image.properties
+++ b/src/main/resources/META-INF/native-image/com.github.chrisvest/stormpot/native-image.properties
@@ -1,2 +1,2 @@
 #Temporary solution. May be removed when this issue is solved: https://github.com/oracle/graal/issues/3028
-Args = --initialize-at-build-time=stormpot.internal.PaddedAtomicInteger,stormpot.internal.BlazePool
+Args = --initialize-at-build-time=stormpot.internal.BSlot,stormpot.internal.BlazePool

--- a/src/test/java/module-info.java
+++ b/src/test/java/module-info.java
@@ -19,7 +19,6 @@ open module stormpot.test {
     requires transitive org.junit.jupiter.params;
     requires transitive org.junit.jupiter.engine;
     requires org.assertj.core;
-    requires jol.core;
     requires com.codahale.metrics;
     requires java.sql;
     requires HdrHistogram;

--- a/src/test/java/stormpot/tests/BSlotTest.java
+++ b/src/test/java/stormpot/tests/BSlotTest.java
@@ -16,46 +16,12 @@
 package stormpot.tests;
 
 import org.junit.jupiter.api.Test;
-import org.openjdk.jol.info.ClassLayout;
-import org.openjdk.jol.vm.VM;
-import org.opentest4j.TestAbortedException;
-import stormpot.Pool;
 import stormpot.Pooled;
-import stormpot.Slot;
-import stormpot.Timeout;
 import stormpot.internal.BSlot;
-import testkits.AlloKit;
-import testkits.GenericPoolable;
-
-import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class BSlotTest {
-  // Blindly assume that cache lines are always 64 bytes wide.
-  // Architectures where this is not the case, will just have to suffer.
-  private static final int CACHE_LINE_SIZE = 64;
-
-  @Test
-  void slotObjectsShouldBeCacheLineAligned() throws Exception {
-    try {
-      VM.current();
-    } catch (IllegalStateException ise) {
-      throw new TestAbortedException("JOL does not support this JVM", ise);
-    }
-    String arch = System.getProperty("os.arch");
-    if (arch.equals("x86_64") || arch.equals("amd64")) { // Only enable this on 64-bit machines.
-      Pool<GenericPoolable> pool = Pool.fromInline(AlloKit.allocator()).setSize(1).build();
-      GenericPoolable object = pool.claim(new Timeout(1, TimeUnit.SECONDS));
-      Slot slot = object.getSlot();
-      ClassLayout classLayout = ClassLayout.parseInstance(slot);
-      long size = classLayout.instanceSize();
-      String description = "BSlot instance size should be an even multiple of 64, " +
-          "but was " + size + ", which is " + (size % CACHE_LINE_SIZE) + " bytes too big:" +
-          System.lineSeparator() + classLayout.toPrintable();
-      assertThat(size % CACHE_LINE_SIZE).as(description).isEqualTo(0);
-    }
-  }
 
   @Test
   void toStringForBSlot() {


### PR DESCRIPTION
This is true by default, and avoids the object padding related to preventing false sharing. This makes slot objects smaller by default.
However, when this setting is turned off, the objects are now padded to 128 bytes, instead of the previous 64 bytes. The 128 matches the cache line size of many large-scale ARM systems, and is also sympathetic to the adjacent cache-line prefetch seen on x86_64 systems.