### PR TITLE
Allow target size to be greater than 2 billion

### DIFF
--- a/api-changes.json
+++ b/api-changes.json
@@ -222,6 +222,50 @@
           "code": "java.method.addedToInterface",
           "new": "method stormpot.PoolBuilder<T> stormpot.PoolBuilder<T extends stormpot.Poolable>::setOptimizeForReducedMemoryUsage(boolean)",
           "justification": "Major version change"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeChanged",
+          "old": "method int stormpot.ManagedPool::getCurrentAllocatedCount()",
+          "new": "method long stormpot.ManagedPool::getCurrentAllocatedCount()",
+          "justification": "Major version change"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeChanged",
+          "old": "method int stormpot.ManagedPool::getCurrentInUseCount()",
+          "new": "method long stormpot.ManagedPool::getCurrentInUseCount()",
+          "justification": "Major version change"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeChanged",
+          "old": "method int stormpot.ManagedPool::getTargetSize()",
+          "new": "method long stormpot.ManagedPool::getTargetSize()",
+          "justification": "Major version change"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeChanged",
+          "old": "parameter void stormpot.ManagedPool::setTargetSize(===int===)",
+          "new": "parameter void stormpot.ManagedPool::setTargetSize(===long===)",
+          "parameterIndex": "0",
+          "justification": "Major version change"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeChanged",
+          "old": "method int stormpot.Pool<T extends stormpot.Poolable>::getTargetSize()",
+          "new": "method long stormpot.Pool<T extends stormpot.Poolable>::getTargetSize()",
+          "justification": "Major version change"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeChanged",
+          "old": "parameter void stormpot.Pool<T extends stormpot.Poolable>::setTargetSize(===int===)",
+          "new": "parameter void stormpot.Pool<T extends stormpot.Poolable>::setTargetSize(===long===)",
+          "parameterIndex": "0",
+          "justification": "Major version change"
         }
       ]
     }

--- a/src/main/java/stormpot/ManagedPool.java
+++ b/src/main/java/stormpot/ManagedPool.java
@@ -74,9 +74,9 @@ public interface ManagedPool {
    * Set a new target size of the pool.
    *
    * @param size The new target size.
-   * @see Pool#setTargetSize(int)
+   * @see Pool#setTargetSize(long)
    */
-  void setTargetSize(int size);
+  void setTargetSize(long size);
 
   /**
    * Get the current target size of the pool.
@@ -84,7 +84,7 @@ public interface ManagedPool {
    * @return The current target size.
    * @see Pool#getTargetSize()
    */
-  int getTargetSize();
+  long getTargetSize();
 
   /**
    * Returns {@code true} if the shutdown process has been started on this pool,
@@ -191,7 +191,7 @@ public interface ManagedPool {
    *
    * @return The current approximate number of allocated objects.
    */
-  default int getCurrentAllocatedCount() {
+  default long getCurrentAllocatedCount() {
     return -1;
   }
   
@@ -207,7 +207,7 @@ public interface ManagedPool {
    *
    * @return number of objects currently in use
    */
-  default int getCurrentInUseCount() {
+  default long getCurrentInUseCount() {
     return -1;
   }
 }

--- a/src/main/java/stormpot/Pool.java
+++ b/src/main/java/stormpot/Pool.java
@@ -43,7 +43,7 @@ import static stormpot.internal.AllocationProcess.threaded;
  * <p>
  * All pools are configured with a certain size, the number of objects that the
  * pool will have allocated at any one time, and they can change this number on
- * the fly using the {@link #setTargetSize(int)} method. The change does not
+ * the fly using the {@link #setTargetSize(long)} method. The change does not
  * take effect immediately, but instead moves the "goal post" and leaves the
  * pool to move towards it at its own pace.
  * <p>
@@ -57,7 +57,7 @@ import static stormpot.internal.AllocationProcess.threaded;
  * <th scope="row">NOTE</th>
  * <td>
  * Pools created with {@link Pool#of(Object[])} are <em>not</em> resizable, and calling
- * {@link Pool#setTargetSize(int)} or {@link ManagedPool#setTargetSize(int)} will
+ * {@link Pool#setTargetSize(long)} or {@link ManagedPool#setTargetSize(long)} will
  * cause an {@link UnsupportedOperationException} to be thrown.
  * </td>
  * </tr>
@@ -255,7 +255,7 @@ public interface Pool<T extends Poolable> extends PoolTap<T> {
    *
    * @param size The new target size of the pool
    */
-  void setTargetSize(int size);
+  void setTargetSize(long size);
 
   /**
    * Get the currently configured target size of the pool. Note that this is
@@ -264,7 +264,7 @@ public interface Pool<T extends Poolable> extends PoolTap<T> {
    *
    * @return The current target size of this pool.
    */
-  int getTargetSize();
+  long getTargetSize();
 
   /**
    * Get the {@link ManagedPool} instance that represents this pool.

--- a/src/main/java/stormpot/PoolBuilder.java
+++ b/src/main/java/stormpot/PoolBuilder.java
@@ -56,8 +56,8 @@ public sealed interface PoolBuilder<T extends Poolable>
    * be thrown when building the pool.
    * <p>
    * Note that the pool size can be modified after the pool has been built, by
-   * calling the {@link Pool#setTargetSize(int)} or
-   * {@link ManagedPool#setTargetSize(int)} methods.
+   * calling the {@link Pool#setTargetSize(long)} or
+   * {@link ManagedPool#setTargetSize(long)} methods.
    *
    * @param size The target pool size. Must be at least 0.
    * @return This {@code PoolBuilder} instance.

--- a/src/main/java/stormpot/internal/AllocationController.java
+++ b/src/main/java/stormpot/internal/AllocationController.java
@@ -36,14 +36,14 @@ public abstract class AllocationController<T extends Poolable> {
   abstract Completion shutdown();
 
   /**
-   * @see Pool#setTargetSize(int)
+   * @see Pool#setTargetSize(long)
    */
-  abstract void setTargetSize(int size);
+  abstract void setTargetSize(long size);
 
   /**
    * @see Pool#getTargetSize()
    */
-  abstract int getTargetSize();
+  abstract long getTargetSize();
 
   /**
    * @see ManagedPool#getAllocationCount()
@@ -63,10 +63,10 @@ public abstract class AllocationController<T extends Poolable> {
   /**
    * @see ManagedPool#getCurrentAllocatedCount()
    */
-  abstract int allocatedSize();
+  abstract long allocatedSize();
   
   /**
    * @see ManagedPool#getCurrentInUseCount()
    */
-  abstract int inUse();
+  abstract long inUse();
 }

--- a/src/main/java/stormpot/internal/BAllocThread.java
+++ b/src/main/java/stormpot/internal/BAllocThread.java
@@ -55,14 +55,14 @@ public final class BAllocThread<T extends Poolable> implements Runnable {
   private final boolean optimizeForMemory;
 
   // Single reader: this. Many writers.
-  private volatile int targetSize;
+  private volatile long targetSize;
   private volatile boolean shutdown;
 
   // Many readers. Single writer: this.
   private volatile long allocationCount;
   private volatile long failedAllocationCount;
 
-  private int size;
+  private long size;
   private boolean didAnythingLastIteration;
   private long consecutiveAllocationFailures;
 
@@ -370,11 +370,11 @@ public final class BAllocThread<T extends Poolable> implements Runnable {
     }
   }
 
-  void setTargetSize(int size) {
+  void setTargetSize(long size) {
     this.targetSize = size;
   }
 
-  int getTargetSize() {
+  long getTargetSize() {
     return targetSize;
   }
 
@@ -403,13 +403,13 @@ public final class BAllocThread<T extends Poolable> implements Runnable {
     dead.offer(slot);
   }
   
-  int allocatedSize() {
+  long allocatedSize() {
     return size;
   }
   
-  int inUse() {
-    int inUse = 0;
-    int liveSize = 0;
+  long inUse() {
+    long inUse = 0;
+    long liveSize = 0;
     for (BSlot<T> slot: live) {
       liveSize++;
       if (slot.isClaimedOrThreadLocal()) {

--- a/src/main/java/stormpot/internal/BlazePool.java
+++ b/src/main/java/stormpot/internal/BlazePool.java
@@ -305,7 +305,7 @@ public final class BlazePool<T extends Poolable> implements Pool<T>, ManagedPool
   }
 
   @Override
-  public void setTargetSize(int size) {
+  public void setTargetSize(long size) {
     if (size < 0) {
       throw new IllegalArgumentException(
           "Target pool size must be positive");
@@ -317,7 +317,7 @@ public final class BlazePool<T extends Poolable> implements Pool<T>, ManagedPool
   }
 
   @Override
-  public int getTargetSize() {
+  public long getTargetSize() {
     return allocator.getTargetSize();
   }
 
@@ -424,12 +424,12 @@ public final class BlazePool<T extends Poolable> implements Pool<T>, ManagedPool
   }
   
   @Override
-  public int getCurrentAllocatedCount() {
+  public long getCurrentAllocatedCount() {
     return allocator.allocatedSize();
   }
   
   @Override
-  public int getCurrentInUseCount() {
+  public long getCurrentInUseCount() {
     return allocator.inUse();
   }
 }

--- a/src/main/java/stormpot/internal/DirectAllocationController.java
+++ b/src/main/java/stormpot/internal/DirectAllocationController.java
@@ -98,14 +98,14 @@ public final class DirectAllocationController<T extends Poolable> extends Alloca
   }
 
   @Override
-  void setTargetSize(int size) {
+  void setTargetSize(long size) {
     throw new UnsupportedOperationException("Target size cannot be changed. " +
         "This pool was created with a fixed set of objects using the Pool.of(...) method. " +
         "Attempted to set target size to " + size + ".");
   }
 
   @Override
-  int getTargetSize() {
+  long getTargetSize() {
     return size;
   }
 
@@ -125,14 +125,14 @@ public final class DirectAllocationController<T extends Poolable> extends Alloca
   }
 
   @Override
-  public int allocatedSize() {
+  public long allocatedSize() {
     return size;
   }
 
   @Override
-  int inUse() {
-    int inUse = 0;
-    int liveSize = 0;
+  long inUse() {
+    long inUse = 0;
+    long liveSize = 0;
     for (BSlot<T> slot: live) {
       liveSize++;
       if (slot.isClaimedOrThreadLocal()) {

--- a/src/main/java/stormpot/internal/ThreadedAllocationController.java
+++ b/src/main/java/stormpot/internal/ThreadedAllocationController.java
@@ -48,12 +48,12 @@ public final class ThreadedAllocationController<T extends Poolable> extends Allo
   }
 
   @Override
-  public void setTargetSize(int size) {
+  public void setTargetSize(long size) {
     allocator.setTargetSize(size);
   }
 
   @Override
-  public int getTargetSize() {
+  public long getTargetSize() {
     return allocator.getTargetSize();
   }
 
@@ -73,12 +73,12 @@ public final class ThreadedAllocationController<T extends Poolable> extends Allo
   }
   
   @Override
-  public int allocatedSize() {
+  public long allocatedSize() {
     return allocator.allocatedSize();
   }
   
   @Override
-  public int inUse() {
+  public long inUse() {
     return allocator.inUse();
   }
 }

--- a/src/test/java/stormpot/tests/WhiteboxPoolTest.java
+++ b/src/test/java/stormpot/tests/WhiteboxPoolTest.java
@@ -41,11 +41,11 @@ class WhiteboxPoolTest {
       }
 
       @Override
-      public void setTargetSize(int size) {
+      public void setTargetSize(long size) {
       }
 
       @Override
-      public int getTargetSize() {
+      public long getTargetSize() {
         return 0;
       }
 


### PR DESCRIPTION
In theory this should allow the pools to contain more than 2 billion objects. The LinkedTransferQueue used internally supposedly support this.

This fixes #142