### PR TITLE
Make completion API reactive

### DIFF
--- a/api-changes.json
+++ b/api-changes.json
@@ -266,6 +266,30 @@
           "new": "parameter void stormpot.Pool<T extends stormpot.Poolable>::setTargetSize(===long===)",
           "parameterIndex": "0",
           "justification": "Major version change"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.addedToInterface",
+          "new": "method boolean java.util.concurrent.ForkJoinPool.ManagedBlocker::block() throws java.lang.InterruptedException @ stormpot.Completion",
+          "justification": "Major version change"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.addedToInterface",
+          "new": "method boolean stormpot.Completion::isCompleted()",
+          "justification": "Major version change"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.addedToInterface",
+          "new": "method boolean java.util.concurrent.ForkJoinPool.ManagedBlocker::isReleasable() @ stormpot.Completion",
+          "justification": "Major version change"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.addedToInterface",
+          "new": "method void java.util.concurrent.Flow.Publisher<T>::subscribe(java.util.concurrent.Flow.Subscriber<? super T>) @ stormpot.Completion",
+          "justification": "Major version change"
         }
       ]
     }

--- a/pom.xml
+++ b/pom.xml
@@ -349,13 +349,13 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.11.0-M2</version>
+      <version>5.11.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
-      <version>5.11.0-M2</version>
+      <version>5.11.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/stormpot/internal/StackCompletion.java
+++ b/src/main/java/stormpot/internal/StackCompletion.java
@@ -1,0 +1,321 @@
+/*
+ * Copyright © 2011-2024 Chris Vest (mr.chrisvest@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package stormpot.internal;
+
+import stormpot.Completion;
+import stormpot.Timeout;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.Objects;
+import java.util.concurrent.Flow;
+import java.util.concurrent.locks.LockSupport;
+
+public final class StackCompletion implements Completion {
+  private static final Node END = new Node("END");
+  private static final Node DONE = new Node("DONE");
+  private static final VarHandle NODES;
+  private static final VarHandle NODE_OBJ;
+  static {
+    MethodHandles.Lookup lookup = MethodHandles.lookup();
+    try {
+      NODES = lookup.findVarHandle(StackCompletion.class, "nodes", Node.class).withInvokeExactBehavior();
+      NODE_OBJ = lookup.findVarHandle(Node.class, "obj", Object.class).withInvokeExactBehavior();
+    } catch (Exception e) {
+      throw new ExceptionInInitializerError(e);
+    }
+  }
+
+  @SuppressWarnings("FieldMayBeFinal") // Accessed via VarHandle
+  private volatile Node nodes;
+  private final OnAwait onAwait;
+  
+  public StackCompletion() {
+    this(null);
+  }
+
+  public StackCompletion(OnAwait onAwait) {
+    nodes = END;
+    this.onAwait = onAwait;
+  }
+
+  private static Node loadNext(Node ns) {
+    Node next = ns.next;
+    if (next == null) {
+      do {
+        int i = 0;
+        do {
+          Thread.onSpinWait();
+          next = ns.next;
+        } while (next == null && ++i < 128);
+        Thread.yield();
+        next = ns.next;
+      } while (next == null);
+    }
+    return next;
+  }
+
+  public void complete() {
+    if (nodes == DONE) {
+      return;
+    }
+
+    Node ns = (Node) NODES.getAndSet(this, DONE);
+    while (ns != END && ns != DONE) {
+      Node next = loadNext(ns);
+      Object obj = ns.obj;
+      if (obj instanceof Thread th) {
+        LockSupport.unpark(th);
+      } else if (obj instanceof Flow.Subscriber<?> subscriber &&
+              ns.compareAndSetObj(subscriber, new CancelledSubscription(subscriber))) {
+        subscriber.onComplete();
+      }
+      ns = next;
+    }
+  }
+
+  @Override
+  public void subscribe(Flow.Subscriber<? super Void> subscriber) {
+    Objects.requireNonNull(subscriber, "Subscriber cannot be null.");
+    if (isCompleted()) {
+      oneOffCompleteSubscriber(subscriber);
+      return;
+    }
+
+    Node ns = nodes;
+    while (ns != END && ns != DONE) {
+      Node next = loadNext(ns);
+      Object obj = ns.obj;
+      if (obj instanceof CancelledSubscription cs && cs.subscriber == subscriber) {
+        if (ns.compareAndSetObj(cs, subscriber)) {
+          subscriber.onSubscribe(ns);
+          if (isCompleted() && ns.compareAndSetObj(subscriber, new CancelledSubscription(subscriber))) {
+            subscriber.onComplete();
+          }
+        }
+        return;
+      }
+      ns = next;
+    }
+
+    if (isCompleted()) {
+      oneOffCompleteSubscriber(subscriber);
+      return;
+    }
+
+    Node node = new Node();
+    Node setNext = node;
+    node.obj = subscriber;
+
+    if (onAwait != null) {
+      setNext = new Node();
+      setNext.obj = new Awaitable(this, onAwait);
+      node.next = setNext;
+    }
+
+    Node existing = (Node) NODES.getAndSet(this, node);
+    setNext.next = existing;
+    subscriber.onSubscribe(node);
+    if (existing == DONE) {
+      complete();
+    }
+  }
+
+  private static void oneOffCompleteSubscriber(Flow.Subscriber<? super Void> subscriber) {
+    Node node = new Node();
+    node.obj = subscriber;
+    node.next = DONE;
+    subscriber.onSubscribe(node);
+    if (node.obj == subscriber) {
+      subscriber.onComplete();
+    }
+  }
+
+  @Override
+  public boolean await(Timeout timeout) throws InterruptedException {
+    Objects.requireNonNull(timeout, "Timeout cannot be null.");
+    return awaitInner(timeout);
+  }
+
+  private boolean awaitInner(Timeout timeout) throws InterruptedException {
+    if (Thread.interrupted()) {
+      throw new InterruptedException();
+    }
+    if (isCompleted()) {
+      return true;
+    }
+
+    long start = timeout == null ? 0 : NanoClock.nanoTime();
+    long timeoutNanos = timeout == null ? 0 : timeout.getTimeoutInBaseUnit();
+
+    Node ns = nodes;
+    while (ns != END && ns != DONE) {
+      Node next = loadNext(ns);
+      Object obj = ns.obj;
+      if (obj == null && ns.compareAndSetObj(null, Thread.currentThread())) {
+        if (nodes == DONE) {
+          return true;
+        } else {
+          return awaitCompletion(start, timeoutNanos, ns);
+        }
+      }
+      ns = next;
+    }
+
+    if (isCompleted()) {
+      return true;
+    }
+
+    if (onAwait != null) {
+      boolean completed = onAwait.await(timeout);
+      if (completed) {
+        complete();
+      }
+      return completed;
+    }
+
+    Node node = new Node();
+    node.obj = Thread.currentThread();
+    Node existing = (Node) NODES.getAndSet(this, node);
+    node.next = existing;
+    if (existing == DONE) {
+      complete();
+      return true;
+    }
+
+    return awaitCompletion(start, timeoutNanos, node);
+  }
+
+  private boolean awaitCompletion(long start, long timeoutNanos, Node node) throws InterruptedException {
+    boolean oneShot = start == 0 && timeoutNanos == 0;
+    long nanos = oneShot ? 1 : NanoClock.timeoutLeft(start, timeoutNanos);
+    while (nanos > 0) {
+      if (oneShot) {
+       LockSupport.park(this);
+      } else {
+        LockSupport.parkNanos(this, nanos);
+      }
+      if (Thread.interrupted()) {
+        throw new InterruptedException();
+      } else if (nodes == DONE) {
+        return true;
+      } else {
+        nanos = oneShot ? 0 : NanoClock.timeoutLeft(start, timeoutNanos);
+      }
+    }
+    node.obj = null;
+    return false;
+  }
+
+  @Override
+  public boolean block() throws InterruptedException {
+    return awaitInner(null);
+  }
+
+  @Override
+  public boolean isReleasable() {
+    return isCompleted();
+  }
+
+  @Override
+  public boolean isCompleted() {
+    Node ns = nodes;
+    while (ns != END) {
+      if (ns == DONE) {
+        return true;
+      }
+      ns = loadNext(ns);
+    }
+    return false;
+  }
+
+  private static class Node implements Flow.Subscription {
+    volatile Node next;
+    volatile Object obj;
+
+    Node() {
+    }
+
+    Node(String mark) {
+      obj = mark;
+    }
+
+    @Override
+    public String toString() {
+      return "Node(" + obj + (next == null ? ")" : ", " + next + ")");
+    }
+
+    boolean compareAndSetObj(Object expected, Object update) {
+      return NODE_OBJ.compareAndSet(this, expected, update);
+    }
+
+    @Override
+    public void request(long n) {
+      Node next = loadNext(this);
+      if (n <= 0 && obj instanceof Flow.Subscriber<?> subscriber) {
+        cancel();
+        subscriber.onError(new IllegalArgumentException("Must request a positive number of objects"));
+        return;
+      }
+      if (next != END && next != DONE) {
+        if (next.obj instanceof Awaitable awaitable) {
+          try {
+            awaitable.await();
+          } catch (InterruptedException e) {
+            if (obj instanceof Flow.Subscriber<?> subscriber) {
+              subscriber.onError(e);
+            } else {
+              Thread.currentThread().interrupt();
+            }
+          }
+        }
+      }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void cancel() {
+      Flow.Subscriber<Void> subscriber;
+      CancelledSubscription cancelled;
+      do {
+        Object curr = obj;
+        if (curr instanceof Flow.Subscriber<?>) {
+          subscriber = (Flow.Subscriber<Void>) curr;
+          cancelled = new CancelledSubscription(subscriber);
+        } else if (curr instanceof CancelledSubscription) {
+          return; // Already cancelled
+        } else {
+          throw new IllegalStateException("Not a subscription node");
+        }
+      } while (!compareAndSetObj(subscriber, cancelled));
+    }
+  }
+
+  private record CancelledSubscription(Flow.Subscriber<?> subscriber) {
+  }
+
+  public interface OnAwait {
+    boolean await(Timeout timeout) throws InterruptedException;
+  }
+
+  private record Awaitable(StackCompletion completion, OnAwait onAwait) {
+    void await() throws InterruptedException {
+      if (onAwait.await(null)) {
+        completion.complete();
+      }
+    }
+  }
+}

--- a/src/test/java/stormpot/tests/MySubscriber.java
+++ b/src/test/java/stormpot/tests/MySubscriber.java
@@ -13,24 +13,36 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package stormpot.internal;
+package stormpot.tests;
 
-import stormpot.Completion;
-import stormpot.Timeout;
+import java.util.concurrent.Flow;
 
-import java.util.Objects;
-import java.util.concurrent.CountDownLatch;
+import static org.junit.jupiter.api.Assertions.fail;
 
-public final class LatchCompletion implements Completion {
-  private final CountDownLatch completionLatch;
-  
-  LatchCompletion(CountDownLatch completionLatch) {
-    this.completionLatch = completionLatch;
+class MySubscriber implements Flow.Subscriber<Void> {
+  final Runnable onComplete;
+
+  MySubscriber(Runnable onComplete) {
+    this.onComplete = onComplete;
   }
 
   @Override
-  public boolean await(Timeout timeout) throws InterruptedException {
-    Objects.requireNonNull(timeout, "Timeout cannot be null.");
-    return completionLatch.await(timeout.getTimeout(), timeout.getUnit());
+  public void onSubscribe(Flow.Subscription subscription) {
+    subscription.request(1);
+  }
+
+  @Override
+  public void onNext(Void item) {
+    fail("No item expected: " + item);
+  }
+
+  @Override
+  public void onError(Throwable throwable) {
+    fail("No error expecte", throwable);
+  }
+
+  @Override
+  public void onComplete() {
+    onComplete.run();
   }
 }

--- a/src/test/java/stormpot/tests/StackCompletionTest.java
+++ b/src/test/java/stormpot/tests/StackCompletionTest.java
@@ -1,0 +1,386 @@
+/*
+ * Copyright © 2011-2024 Chris Vest (mr.chrisvest@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package stormpot.tests;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import stormpot.Completion;
+import stormpot.Timeout;
+import stormpot.internal.StackCompletion;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Flow;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.LockSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static testkits.UnitKit.capture;
+import static testkits.UnitKit.fork;
+import static testkits.UnitKit.forkFuture;
+import static testkits.UnitKit.waitForThreadState;
+
+class StackCompletionTest {
+  static final Timeout longTimeout = new Timeout(5, TimeUnit.MINUTES);
+
+  protected Completion completion;
+  protected CompletionStage<Object> stage;
+
+  @BeforeEach
+  void setUp() {
+    completion = new StackCompletion();
+  }
+
+  void complete() {
+    ((StackCompletion) completion).complete();
+  }
+
+  @Test
+  void mustBlockThreadUntilCompletion() throws Exception {
+    Thread th = fork(() -> {
+      assertTrue(completion.await(longTimeout));
+      return null;
+    });
+    AtomicReference<Throwable> exception = capture(th);
+    waitForThreadState(th, Thread.State.TIMED_WAITING);
+    complete();
+    th.join();
+    assertThat(exception).hasNullValue();
+  }
+
+  @Test
+  void isCompleteMustReflectCompletion() {
+    assertFalse(completion.isCompleted());
+    assertFalse(completion.isReleasable());
+    complete();
+    assertTrue(completion.isCompleted());
+    assertTrue(completion.isReleasable());
+  }
+
+  @Test
+  void completionMustNotifySubscribers() throws Exception {
+    AtomicInteger counter = new AtomicInteger();
+    completion.subscribe(new MySubscriber(counter::incrementAndGet));
+    CyclicBarrier barrier = new CyclicBarrier(10);
+    List<Future<Object>> futures = new ArrayList<>();
+    for (int i = 0; i < barrier.getParties(); i++) {
+      futures.add(forkFuture(() -> {
+        barrier.await();
+        complete();
+        return null;
+      }));
+    }
+    for (Future<Object> future : futures) {
+      future.get();
+    }
+    assertEquals(1, counter.get());
+  }
+
+  @Test
+  void completionMustNotNotifyCancelledSubscribers() throws Exception {
+    AtomicInteger counter = new AtomicInteger();
+    completion.subscribe(new MySubscriber(counter::incrementAndGet) {
+      @Override
+      public void onSubscribe(Flow.Subscription subscription) {
+        subscription.cancel();
+      }
+    });
+    CyclicBarrier barrier = new CyclicBarrier(10);
+    List<Future<Object>> futures = new ArrayList<>();
+    for (int i = 0; i < barrier.getParties(); i++) {
+      futures.add(forkFuture(() -> {
+        barrier.await();
+        complete();
+        return null;
+      }));
+    }
+    for (Future<Object> future : futures) {
+      future.get();
+    }
+    assertEquals(0, counter.get());
+  }
+
+  @Test
+  void completionMustNotifyNewSubscribersAfterCompletion() {
+    complete();
+    AtomicInteger counter = new AtomicInteger();
+    completion.subscribe(new MySubscriber(counter::incrementAndGet));
+    assertEquals(1, counter.get());
+  }
+
+  @Test
+  void subscriptionCancelMustBeIdempotent() {
+    AtomicInteger counter = new AtomicInteger();
+    completion.subscribe(new MySubscriber(counter::incrementAndGet) {
+      @Override
+      public void onSubscribe(Flow.Subscription subscription) {
+        subscription.cancel();
+        subscription.cancel();
+      }
+    });
+    complete();
+    assertEquals(0, counter.get());
+  }
+
+  @Test
+  void requestOnCancelledSubscriptionMustDoNothing() {
+    AtomicInteger counter = new AtomicInteger();
+    completion.subscribe(new MySubscriber(counter::incrementAndGet) {
+      @Override
+      public void onSubscribe(Flow.Subscription subscription) {
+        subscription.cancel();
+        subscription.request(1);
+      }
+    });
+    complete();
+    assertEquals(0, counter.get());
+  }
+
+  @Test
+  void completedCompletionMustNotNotifySubscribersThatCancelImmediately() {
+    AtomicInteger counter = new AtomicInteger();
+    complete();
+    completion.subscribe(new MySubscriber(counter::incrementAndGet) {
+      @Override
+      public void onSubscribe(Flow.Subscription subscription) {
+        subscription.cancel();
+      }
+    });
+    assertEquals(0, counter.get());
+  }
+
+  @Test
+  void mustNotifySubscriberRequestingZeroMessages() {
+    AtomicReference<Throwable> onError = new AtomicReference<>();
+    AtomicInteger counter = new AtomicInteger();
+    completion.subscribe(new MySubscriber(counter::incrementAndGet) {
+      @Override
+      public void onSubscribe(Flow.Subscription subscription) {
+        subscription.request(0);
+        subscription.request(0);
+      }
+
+      @Override
+      public void onError(Throwable throwable) {
+        assertNull(onError.getAndSet(throwable));
+      }
+    });
+    assertThat(onError.get()).hasMessageContaining("positive number");
+  }
+
+  @Test
+  void mustNotifySubscriberRequestingNegativeMessages() {
+    AtomicReference<Throwable> onError = new AtomicReference<>();
+    AtomicInteger counter = new AtomicInteger();
+    completion.subscribe(new MySubscriber(counter::incrementAndGet) {
+      @Override
+      public void onSubscribe(Flow.Subscription subscription) {
+        subscription.request(-1);
+        subscription.request(-1);
+      }
+
+      @Override
+      public void onError(Throwable throwable) {
+        assertNull(onError.getAndSet(throwable));
+      }
+    });
+    assertThat(onError.get()).hasMessageContaining("positive number");
+  }
+
+  @Test
+  void managedBlockMustUnblockByCompletion() {
+    Thread thread = fork(() -> {
+      while (!completion.block()) {
+        Thread.onSpinWait();
+      }
+      assertTrue(completion.isReleasable());
+      return null;
+    });
+    waitForThreadState(thread, Thread.State.WAITING);
+    complete();
+  }
+
+  @Test
+  void managedBlockMustAllowSpuriousUnblock() {
+    Thread thread = fork(() -> {
+      assertFalse(completion.block());
+      return null;
+    });
+    AtomicReference<Throwable> capture = capture(thread);
+    waitForThreadState(thread, Thread.State.WAITING);
+    LockSupport.unpark(thread);
+    complete();
+    assertThat(capture).hasNullValue();
+  }
+
+  @RepeatedTest(50)
+  void mustCopeWithAllActionsRacingTogether() throws Exception {
+    CyclicBarrier barrier = new CyclicBarrier(9);
+    List<Thread> threads = new ArrayList<>();
+    List<AtomicReference<Throwable>> exceptions = new ArrayList<>();
+    AtomicInteger countCompletions = new AtomicInteger();
+    AtomicInteger countNoCompletions = new AtomicInteger();
+    AtomicInteger countAwaits = new AtomicInteger();
+
+    for (int i = 0; i < 2; i++) {
+      Thread thread = fork(() -> {
+        barrier.await();
+        complete();
+        return null;
+      });
+      exceptions.add(capture(thread));
+      threads.add(thread);
+    }
+
+    for (int i = 0; i < 2; i++) {
+      Thread thread = fork(() -> {
+        barrier.await();
+        completion.subscribe(new MySubscriber(countCompletions::incrementAndGet));
+        return null;
+      });
+      exceptions.add(capture(thread));
+      threads.add(thread);
+    }
+
+    for (int i = 0; i < 2; i++) {
+      Thread thread = fork(() -> {
+        barrier.await();
+        completion.subscribe(new MySubscriber(countNoCompletions::incrementAndGet) {
+          @Override
+          public void onSubscribe(Flow.Subscription subscription) {
+            subscription.cancel();
+          }
+        });
+        return null;
+      });
+      exceptions.add(capture(thread));
+      threads.add(thread);
+    }
+
+    for (int i = 0; i < 2; i++) {
+      Thread thread = fork(() -> {
+        barrier.await();
+        completion.await(new Timeout(1, TimeUnit.MINUTES));
+        countAwaits.incrementAndGet();
+        return null;
+      });
+      exceptions.add(capture(thread));
+      threads.add(thread);
+    }
+
+    barrier.await();
+    for (Thread thread : threads) {
+      thread.join();
+    }
+
+    try {
+      assertEquals(2, countCompletions.get());
+      assertThat(countNoCompletions).hasValueBetween(0, 2); // The cancel and onComplete methods can race.
+      assertEquals(2, countAwaits.get());
+    } catch (Throwable e) {
+      for (AtomicReference<Throwable> exception : exceptions) {
+        Throwable suppressed = exception.get();
+        if (suppressed != null) {
+          e.addSuppressed(suppressed);
+        }
+      }
+      throw e;
+    }
+
+    Throwable e = null;
+    for (AtomicReference<Throwable> exception : exceptions) {
+      Throwable throwable = exception.get();
+      if (throwable != null) {
+        if (e == null) {
+          e = throwable;
+        } else {
+          e.addSuppressed(throwable);
+        }
+      }
+    }
+    if (e != null) {
+      fail("Forked thread got exception", e);
+    }
+  }
+
+  @Test
+  void mustNotifyWhenResubscribingAfterCancel() {
+    AtomicInteger counter = new AtomicInteger();
+    MySubscriber subscriber = new MySubscriber(counter::incrementAndGet) {
+      boolean first = true;
+
+      @Override
+      public void onSubscribe(Flow.Subscription subscription) {
+        if (first) {
+          subscription.cancel();
+          first = false;
+        }
+        super.onSubscribe(subscription);
+      }
+    };
+    completion.subscribe(subscriber);
+    completion.subscribe(subscriber);
+    complete();
+    assertEquals(1, counter.get());
+  }
+
+  @Test
+  void mustNotifyWhenSubscribeCompletes() {
+    AtomicInteger counter = new AtomicInteger();
+    MySubscriber subscriber = new MySubscriber(counter::incrementAndGet) {
+      @Override
+      public void onSubscribe(Flow.Subscription subscription) {
+        complete();
+        super.onSubscribe(subscription);
+      }
+    };
+    completion.subscribe(subscriber);
+    assertEquals(1, counter.get());
+  }
+
+  @Test
+  void mustNotifyWhenResubscribeCompletes() {
+    AtomicInteger counter = new AtomicInteger();
+    MySubscriber subscriber = new MySubscriber(counter::incrementAndGet) {
+      boolean first = true;
+
+      @Override
+      public void onSubscribe(Flow.Subscription subscription) {
+        if (first) {
+          subscription.cancel();
+          first = false;
+        } else {
+          complete();
+        }
+        super.onSubscribe(subscription);
+      }
+    };
+    completion.subscribe(subscriber);
+    completion.subscribe(subscriber);
+    assertEquals(1, counter.get());
+  }
+}

--- a/src/test/java/stormpot/tests/StackCompletionWithCompletionStageTest.java
+++ b/src/test/java/stormpot/tests/StackCompletionWithCompletionStageTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2011-2024 Chris Vest (mr.chrisvest@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package stormpot.tests;
+
+import org.junit.jupiter.api.BeforeEach;
+import stormpot.Completion;
+
+import java.util.concurrent.CompletableFuture;
+
+public class StackCompletionWithCompletionStageTest extends StackCompletionTest {
+  @BeforeEach
+  @Override
+  void setUp() {
+    stage = new CompletableFuture<>();
+    completion = Completion.from(stage);
+  }
+
+  @Override
+  void complete() {
+    ((CompletableFuture<?>) stage).complete(null);
+  }
+}

--- a/src/test/java/stormpot/tests/StackCompletionWithOnAwaitTest.java
+++ b/src/test/java/stormpot/tests/StackCompletionWithOnAwaitTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2011-2024 Chris Vest (mr.chrisvest@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package stormpot.tests;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import stormpot.Timeout;
+import stormpot.internal.StackCompletion;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class StackCompletionWithOnAwaitTest {
+  private static final Timeout timeout = new Timeout(1, TimeUnit.MINUTES);
+
+  BlockingQueue<StackCompletion.OnAwait> awaits;
+  StackCompletion completion;
+
+  @BeforeEach
+  void setUp() {
+    awaits = new LinkedBlockingQueue<>();
+    completion = new StackCompletion(timeout -> {
+      StackCompletion.OnAwait await = awaits.poll();
+      if (await == null) {
+        fail("No awaits expected");
+      }
+      return await.await(timeout);
+    });
+  }
+
+  @Test
+  void mustRunOnAwaitOnlyOnceWhenItCompletes() throws Exception {
+    AtomicInteger counter = new AtomicInteger();
+    awaits.put(timeout -> {
+      counter.incrementAndGet();
+      return true;
+    });
+    assertTrue(completion.await(timeout));
+    assertTrue(completion.isCompleted());
+    assertTrue(completion.await(timeout));
+    assertEquals(1, counter.get());
+  }
+
+  @Test
+  void mustRunOnAwaitMultipleTimesUntilItCompletes() throws Exception {
+    AtomicInteger counter = new AtomicInteger();
+    awaits.put(timeout -> counter.incrementAndGet() > 1);
+    awaits.put(timeout -> counter.incrementAndGet() > 1);
+    assertFalse(completion.await(timeout));
+    assertFalse(completion.isCompleted());
+    assertTrue(completion.await(timeout));
+    assertTrue(completion.isCompleted());
+    assertEquals(2, counter.get());
+  }
+
+  @Test
+  void mustRunOnAwaitFromBlockMethod() throws Exception {
+    AtomicInteger counter = new AtomicInteger();
+    awaits.put(timeout -> counter.incrementAndGet() > 1);
+    awaits.put(timeout -> counter.incrementAndGet() > 1);
+    assertFalse(completion.block());
+    assertFalse(completion.isCompleted());
+    assertTrue(completion.block());
+    assertTrue(completion.isCompleted());
+    assertEquals(2, counter.get());
+  }
+
+  @Test
+  void mustRunOnAwaitFromSubscriberRequestMethod() throws Exception {
+    AtomicInteger awaitCounter = new AtomicInteger();
+    AtomicInteger completionCounter = new AtomicInteger();
+    awaits.put(timeout -> awaitCounter.incrementAndGet() > 0);
+    MySubscriber subscriber = new MySubscriber(completionCounter::incrementAndGet);
+    completion.subscribe(subscriber);
+    assertTrue(completion.isCompleted());
+    assertEquals(1, awaitCounter.get());
+    assertEquals(1, completionCounter.get());
+  }
+
+  @Test
+  void awaitInterruptMustSignalErrorToSubscriber() throws Exception {
+    AtomicReference<Throwable> error = new AtomicReference<>();
+    AtomicInteger completionCounter = new AtomicInteger();
+    awaits.put(timeout -> {
+      throw new InterruptedException();
+    });
+    MySubscriber subscriber = new MySubscriber(completionCounter::incrementAndGet) {
+      @Override
+      public void onError(Throwable throwable) {
+        assertNull(error.getAndSet(throwable));
+      }
+    };
+    completion.subscribe(subscriber);
+    assertEquals(0, completionCounter.get());
+    assertThat(error.get()).isInstanceOf(InterruptedException.class);
+  }
+}


### PR DESCRIPTION
It's now possible to receive callbacks from `Completion` objects when they complete, by attaching a `Flow.Subscriber` to them.

Additionally, the `Completion` interface now extends `ManagedBlocker` so it can be safely used in a fork/join context.