### PR TITLE
Fix subscribed-to shutdown completions

### DIFF
--- a/src/test/java/stormpot/tests/MySubscriber.java
+++ b/src/test/java/stormpot/tests/MySubscriber.java
@@ -19,10 +19,10 @@ import java.util.concurrent.Flow;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
-class MySubscriber implements Flow.Subscriber<Void> {
+public class MySubscriber implements Flow.Subscriber<Void> {
   final Runnable onComplete;
 
-  MySubscriber(Runnable onComplete) {
+  public MySubscriber(Runnable onComplete) {
     this.onComplete = onComplete;
   }
 


### PR DESCRIPTION
We can't complete shutdown processes from `Subscription.request()` because the subscribing thread might be owning claimed objects, and would thus self-deadlock.

The inline and direct allocation processes need to cache and only use a single StackCompletion for shutdown, so that all subscribers are notified upon shutdown completion.