### PR TITLE
Update the ThreadTransfer benchmark

### DIFF
--- a/benchmarks/src/main/java/stormpot/benchmarks/ThreadTransfer.java
+++ b/benchmarks/src/main/java/stormpot/benchmarks/ThreadTransfer.java
@@ -15,33 +15,43 @@
  */
 package stormpot.benchmarks;
 
-import org.jctools.queues.SpscArrayQueue;
+import org.jctools.queues.MpscArrayQueue;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Group;
+import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
-import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.infra.Control;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
 import stormpot.Completion;
 import stormpot.Expiration;
 import stormpot.Pool;
 import stormpot.Timeout;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
-@Threads(2)
 @Fork(jvmArgsAppend = {"-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints"})
 @State(Scope.Benchmark)
 public class ThreadTransfer {
-  private static final stormpot.Timeout timeout = new Timeout(1, TimeUnit.MILLISECONDS);
+  private static final stormpot.Timeout timeout = new Timeout(10, TimeUnit.MILLISECONDS);
 
   @Param({"2048"})
   public int poolSize;
+  @Param({"100"})
+  public int cpuTokens;
+
   Pool<GenericPoolable> pool;
-  SpscArrayQueue<GenericPoolable> queue;
+  MpscArrayQueue<GenericPoolable> queue;
+  Thread consumer;
 
   @Setup
   public void setUp() {
@@ -51,7 +61,7 @@ public class ThreadTransfer {
             .setPreciseLeakDetectionEnabled(false)
             .setOptimizeForReducedMemoryUsage(false)
             .build();
-    queue = new SpscArrayQueue<>(poolSize * 2);
+    queue = new MpscArrayQueue<>(poolSize * 2);
   }
 
   @TearDown
@@ -61,21 +71,46 @@ public class ThreadTransfer {
     completion.await(timeout);
   }
 
+  @Setup(Level.Iteration)
+  public void startConsumer(Control infraControl) {
+    AtomicBoolean consumerStart = new AtomicBoolean();
+    consumer = Thread.ofPlatform().name("releaser").start(() -> {
+      consumerStart.set(true);
+      while (!infraControl.startMeasurement) {
+        Thread.onSpinWait();
+      }
+      while (!infraControl.stopMeasurement) {
+        queue.drain(GenericPoolable::release, 16);
+      }
+    });
+    while (!consumerStart.get()) {
+      Thread.onSpinWait();
+    }
+  }
+
+  @TearDown(Level.Iteration)
+  public void stopConsumer() throws InterruptedException {
+    consumer.join();
+  }
+
   @Benchmark
-  @Group("claim")
   public void claim() throws InterruptedException {
     GenericPoolable obj = pool.claim(timeout);
     if (obj != null) {
       queue.offer(obj);
     }
+    Blackhole.consumeCPU(cpuTokens);
   }
 
-  @Benchmark
-  @Group("claim")
-  public void release() {
-    GenericPoolable obj = queue.poll();
-    if (obj != null) {
-      obj.release();
-    }
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+            .include(ThreadTransfer.class.getSimpleName())
+            .measurementTime(TimeValue.seconds(1))
+            .warmupTime(TimeValue.seconds(1))
+            .forks(0) // For debugging.
+            .threads(4)
+            .build();
+
+    new Runner(opt).run();
   }
 }


### PR DESCRIPTION
This moves the consumer/releaser thread to a dedicated infra thread, instead of being part of an asymmetric benchmark. The releaser thread remains a singleton while the claim benchmark threads can be scaled to measure contention on the `Pool.claim()` call.

Some blackholde CPU consumption has also been added, to place some realistic distance between the individual `claim()` calls. This is another vector for scaling contention up or down.