### PR TITLE
Fix data race in StackCompletion

### DIFF
--- a/src/main/java/stormpot/internal/BAllocThread.java
+++ b/src/main/java/stormpot/internal/BAllocThread.java
@@ -443,7 +443,6 @@ public final class BAllocThread<T extends Poolable> implements Runnable {
     StackCompletion completion = new StackCompletion();
     Reallocator<T> reallocator = ReallocatingAdaptor.adapt(replacementAllocator, metricsRecorder);
     AllocatorSwitch<T> switchRequest = new AllocatorSwitch<>(completion, reallocator);
-    switchRequests.offer(switchRequest);
     if (shutdown) {
       AllocatorSwitch<T> entry;
       while ((entry = switchRequests.poll()) != null) {
@@ -451,6 +450,7 @@ public final class BAllocThread<T extends Poolable> implements Runnable {
       }
     } else {
       shutdownCompletion.propagateTo(completion);
+      switchRequests.offer(switchRequest);
     }
     return completion;
   }

--- a/src/main/java/stormpot/internal/BaseSubscriber.java
+++ b/src/main/java/stormpot/internal/BaseSubscriber.java
@@ -15,6 +15,7 @@
  */
 package stormpot.internal;
 
+import java.util.Objects;
 import java.util.concurrent.Flow;
 
 class BaseSubscriber implements Flow.Subscriber<Void> {
@@ -22,7 +23,7 @@ class BaseSubscriber implements Flow.Subscriber<Void> {
 
   @Override
   public void onSubscribe(Flow.Subscription subscription) {
-    this.subscription = subscription;
+    this.subscription = Objects.requireNonNull(subscription, "subscription");
   }
 
   @Override

--- a/src/main/java/stormpot/internal/StackCompletion.java
+++ b/src/main/java/stormpot/internal/StackCompletion.java
@@ -82,7 +82,7 @@ public final class StackCompletion implements Completion {
         do {
           Thread.onSpinWait();
           next = ns.next;
-        } while (next == null && ++i < 128);
+        } while (next == null && ++i < 256);
         Thread.yield();
         next = ns.next;
       } while (next == null);
@@ -141,9 +141,9 @@ public final class StackCompletion implements Completion {
 
     Node node = new Node();
     node.obj = subscriber;
+    subscriber.onSubscribe(node);
     Node existing = (Node) NODES.getAndSet(this, node);
     node.next = existing;
-    subscriber.onSubscribe(node);
     if (existing == DONE) {
       complete();
     }
@@ -310,7 +310,6 @@ public final class StackCompletion implements Completion {
 
     @Override
     public void request(long n) {
-      loadNext(this); // We must do this before we can safely load 'obj'.
       if (n <= 0 && obj instanceof Flow.Subscriber<?> subscriber) {
         cancel();
         subscriber.onError(new IllegalArgumentException("Must request a positive number of objects"));


### PR DESCRIPTION
When StackCompletion is used as a Flow.Publisher, new subscribers would be added to the stack before the onSubscribe method had been called. This allowed onComplete callbacks to arrive before the subscriber had subscribed, and lead to NullPointerExceptions in the onComplete because the BaseSubscriber.subscription was null.

The fix is to call onSubscribe before adding the node to the stack.